### PR TITLE
runtime: test and fixes to run basic drivers

### DIFF
--- a/runtime/image.go
+++ b/runtime/image.go
@@ -76,7 +76,16 @@ func (d *driverImage) WriteTo(path string) error {
 	}
 
 	defer img.Close()
-	return utils.UnpackImage(img, path)
+	if err := utils.UnpackImage(img, path); err != nil {
+		return err
+	}
+
+	config, err := img.OCIConfig()
+	if err != nil {
+		return err
+	}
+
+	return utils.WriteImageConfig(config, path+".json")
 }
 
 func (d *driverImage) image() (types.Image, error) {

--- a/runtime/image_test.go
+++ b/runtime/image_test.go
@@ -28,7 +28,7 @@ func TestDriverImageFromNonNormalizedName(t *testing.T) {
 func TestDriverImageDigest(t *testing.T) {
 	require := require.New(t)
 	IfNetworking(t)
-	
+
 	d, err := NewDriverImage("//smolav/busybox-test-image:latest")
 	require.NoError(err)
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"syscall"
 
+	"github.com/bblfsh/server/utils"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	_ "github.com/opencontainers/runc/libcontainer/nsenter"
@@ -74,12 +75,17 @@ func (r *Runtime) Container(d DriverImage, p *Process) (Container, error) {
 		return nil, err
 	}
 
+	imgConfig, err := utils.ReadImageConfig(cfg.Rootfs + ".json")
+	if err != nil {
+		return nil, err
+	}
+
 	c, err := r.f.Create(NewULID().String(), cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	return newContainer(c, p), nil
+	return newContainer(c, p, imgConfig), nil
 }
 
 // ContainerConfigFactory is the default container config factory, is returns a

--- a/utils/config.go
+++ b/utils/config.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func WriteImageConfig(config *v1.Image, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	var cerr error
+	defer func() { cerr = f.Close() }()
+
+	enc := json.NewEncoder(f)
+	if err := enc.Encode(config); err != nil {
+		return err
+	}
+
+	return cerr
+}
+
+func ReadImageConfig(path string) (*v1.Image, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var cerr error
+	defer func() { cerr = f.Close() }()
+
+	dec := json.NewDecoder(f)
+	config := &v1.Image{}
+	if err := dec.Decode(config); err != nil {
+		return nil, err
+	}
+
+	return config, cerr
+}

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteImageConfig(t *testing.T) {
+	require := require.New(t)
+
+	f, err := ioutil.TempFile(os.TempDir(), "test")
+	require.NoError(err)
+	path := f.Name()
+	require.NoError(f.Close())
+
+	err = WriteImageConfig(&v1.Image{
+		Author: "foo",
+		OS:     "bar",
+	}, path)
+	require.NoError(err)
+
+	b, err := ioutil.ReadFile(path)
+	require.NoError(err)
+	require.Equal("{\"created\":\"0001-01-01T00:00:00Z\",\"author\":\"foo\",\"architecture\":\"\",\"os\":\"bar\",\"config\":{},\"rootfs\":{\"type\":\"\",\"diff_ids\":null}}\n", string(b))
+}
+
+func TestReadImageConfig(t *testing.T) {
+	require := require.New(t)
+
+	f, err := ioutil.TempFile(os.TempDir(), "test")
+	require.NoError(err)
+	path := f.Name()
+	require.NoError(f.Close())
+
+	content := "{\"created\":\"0001-01-01T00:00:00Z\",\"author\":\"foo\",\"architecture\":\"\",\"os\":\"bar\",\"config\":{},\"rootfs\":{\"type\":\"\",\"diff_ids\":null}}\n"
+	err = ioutil.WriteFile(path, []byte(content), 0644)
+	require.NoError(err)
+
+	config, err := ReadImageConfig(path)
+	require.NoError(err)
+
+	require.Equal(&v1.Image{
+		Author: "foo",
+		OS:     "bar",
+	}, config)
+
+}


### PR DESCRIPTION
This PR includes fixes and tests required to run drivers:

* Tests run a privileged container.
* Image metadata is imported and later used to restore environment variables in containers.
* runtime.Bootstrap() needs to run in tests.
* Avoid requiring capabilities when we don't need to.