### PR TITLE
fix default image reference for docker transport

### DIFF
--- a/common.go
+++ b/common.go
@@ -15,5 +15,11 @@ func DefaultDriverImageReference(transport, lang string) string {
 		transport = DefaultTransport
 	}
 
-	return fmt.Sprintf("%s:bblfsh/%s-driver:latest", transport, lang)
+	ref := fmt.Sprintf("bblfsh/%s-driver:latest", lang)
+	switch transport {
+	case "docker":
+		ref = "//" + ref
+	}
+
+	return fmt.Sprintf("%s:%s", transport, ref)
 }

--- a/common_test.go
+++ b/common_test.go
@@ -1,7 +1,20 @@
 package server
 
-import "github.com/Sirupsen/logrus"
+import (
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
 
 func init() {
 	logrus.SetLevel(logrus.DebugLevel)
+}
+
+func TestDefaultDriverImageReference(t *testing.T) {
+	require := require.New(t)
+
+	require.Equal("docker://bblfsh/python-driver:latest", DefaultDriverImageReference("docker", "python"))
+	require.Equal("docker://bblfsh/python-driver:latest", DefaultDriverImageReference("", "python"))
+	require.Equal("docker-daemon:bblfsh/python-driver:latest", DefaultDriverImageReference("docker-daemon", "python"))
 }


### PR DESCRIPTION
docker: requires // prefix, docker-daemon: requires absence of it.