### PR TITLE
pool: use a new scaling policy instance per pool

### DIFF
--- a/pool_test.go
+++ b/pool_test.go
@@ -33,7 +33,7 @@ func TestDriverPoolStartNoopClose(t *testing.T) {
 		return &mockDriver{}, nil
 	}
 
-	dp, err := StartDriverPool(DefaultScalingPolicy, DefaultPoolTimeout, new)
+	dp, err := StartDriverPool(DefaultScalingPolicy(), DefaultPoolTimeout, new)
 	require.NoError(err)
 	require.NotNil(dp)
 
@@ -56,7 +56,7 @@ func TestDriverPoolStartFailingDriver(t *testing.T) {
 		return nil, fmt.Errorf("driver error")
 	}
 
-	dp, err := StartDriverPool(DefaultScalingPolicy, DefaultPoolTimeout, new)
+	dp, err := StartDriverPool(DefaultScalingPolicy(), DefaultPoolTimeout, new)
 	require.EqualError(err, "driver error")
 	require.Nil(dp)
 }
@@ -74,7 +74,7 @@ func TestDriverPoolSequential(t *testing.T) {
 		}, nil
 	}
 
-	dp, err := StartDriverPool(DefaultScalingPolicy, DefaultPoolTimeout, new)
+	dp, err := StartDriverPool(DefaultScalingPolicy(), DefaultPoolTimeout, new)
 	require.NoError(err)
 	require.NotNil(dp)
 
@@ -103,7 +103,7 @@ func TestDriverPoolParallel(t *testing.T) {
 		}, nil
 	}
 
-	dp, err := StartDriverPool(DefaultScalingPolicy, time.Second*10, new)
+	dp, err := StartDriverPool(DefaultScalingPolicy(), time.Second*10, new)
 	require.NoError(err)
 	require.NotNil(dp)
 

--- a/server.go
+++ b/server.go
@@ -64,7 +64,7 @@ func (s *Server) AddDriver(lang string, img string) error {
 		return ErrRuntime.Wrap(err)
 	}
 
-	dp, err := StartDriverPool(DefaultScalingPolicy, DefaultPoolTimeout, func() (Driver, error) {
+	dp, err := StartDriverPool(DefaultScalingPolicy(), DefaultPoolTimeout, func() (Driver, error) {
 		return ExecDriver(s.rt, image)
 	})
 	if err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -46,7 +46,7 @@ func TestNewServerMockedDriverParallelClients(t *testing.T) {
 	require.NoError(err)
 
 	s := NewServer(r)
-	dp, err := StartDriverPool(DefaultScalingPolicy, DefaultPoolTimeout, func() (Driver, error) {
+	dp, err := StartDriverPool(DefaultScalingPolicy(), DefaultPoolTimeout, func() (Driver, error) {
 		return &echoDriver{}, nil
 	})
 	require.NoError(err)


### PR DESCRIPTION
Otherwise, any stateful policy will be broken (and currently
the default is).