### PR TITLE
[fix][vendoring] Rename simple-linguist to enry

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -223,7 +223,7 @@ imports:
   - transport
 - name: gopkg.in/src-d/go-errors.v0
   version: 0c303ec4c027302259ec1738f19f515aad25f13f
-- name: gopkg.in/src-d/simple-linguist.v1
+- name: gopkg.in/src-d/enry.v1
   version: 708f2e40bf35cdc6760a11293cad0a8e632b31a1
 - name: gopkg.in/toqueteos/substring.v1
   version: c5f61671513240ddf5563635cc4a90e9f3ae4710

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,7 +29,7 @@ import:
   - http2
 - package: github.com/oklog/ulid
 - package: github.com/Sirupsen/logrus
-- package: gopkg.in/src-d/simple-linguist.v1
+- package: gopkg.in/src-d/enry.v1
 testImport:
 - package: github.com/stretchr/testify
   subpackages:

--- a/language.go
+++ b/language.go
@@ -11,7 +11,7 @@ import (
 func GetLanguage(filename string, content []byte) string {
 	lang := enry.GetLanguage(filename, content)
 	if lang == "" {
-		lang = slinguist.OtherLanguage
+		lang = enry.OtherLanguage
 	}
 
 	lang = strings.ToLower(lang)


### PR DESCRIPTION
Simple rename of simple-linguist to enry in the Glide files and one source file. This actually fix the build of the server for me (previously it gave an error about an "internal reference" to a module), which should not happen since in theory they're the same tags but happens anyway.