### PR TITLE
replace simple-linguist import with enry

### DIFF
--- a/language.go
+++ b/language.go
@@ -1,14 +1,15 @@
 package server
 
 import (
-	"gopkg.in/src-d/simple-linguist.v1"
 	"strings"
+
+	enry "gopkg.in/src-d/enry.v1"
 )
 
 // GetLanguage detects the language of a file and returns it in a normalized
 // form.
 func GetLanguage(filename string, content []byte) string {
-	lang := slinguist.GetLanguage(filename, content)
+	lang := enry.GetLanguage(filename, content)
 	if lang == "" {
 		lang = slinguist.OtherLanguage
 	}


### PR DESCRIPTION
Changes the import from simple-linguist to enry so it does not complain about using internal of enry.