### PR TITLE
cmd: Add log-level option

### DIFF
--- a/cmd/bblfsh/client.go
+++ b/cmd/bblfsh/client.go
@@ -22,12 +22,19 @@ type clientCmd struct {
 	RuntimePath string `long:"runtime-path" description:"runtime path for standalone mode" default:"/tmp/bblfsh-runtime"`
 	ImageRef    string `long:"image" value-name:"image-ref" description:"image reference to use (e.g. docker://bblfsh/python-driver:latest)"`
 	Language    string `long:"language" description:"language of the input" default:""`
+	LogLevel    string `long:"log-level" description:"log level" default:"debug"`
 	Args        struct {
 		File string `positional-arg-name:"file" required:"true"`
 	} `positional-args:"yes"`
 }
 
 func (c *clientCmd) Execute(args []string) error {
+	level, err := logrus.ParseLevel(c.LogLevel)
+	if err != nil {
+		return err
+	}
+	logrus.SetLevel(level)
+
 	logrus.Debugf("reading file: %s", c.Args.File)
 	content, err := ioutil.ReadFile(c.Args.File)
 	if err != nil {

--- a/cmd/bblfsh/client.go
+++ b/cmd/bblfsh/client.go
@@ -17,24 +17,21 @@ import (
 )
 
 type clientCmd struct {
+	commonCmd
 	Address     string `long:"address" description:"server address to connect to" default:"localhost:9432"`
 	Standalone  []bool `long:"standalone" description:"run standalone, without server"`
 	RuntimePath string `long:"runtime-path" description:"runtime path for standalone mode" default:"/tmp/bblfsh-runtime"`
 	ImageRef    string `long:"image" value-name:"image-ref" description:"image reference to use (e.g. docker://bblfsh/python-driver:latest)"`
 	Language    string `long:"language" description:"language of the input" default:""`
-	LogLevel    string `long:"log-level" description:"log level" default:"debug"`
 	Args        struct {
 		File string `positional-arg-name:"file" required:"true"`
 	} `positional-args:"yes"`
 }
 
 func (c *clientCmd) Execute(args []string) error {
-	level, err := logrus.ParseLevel(c.LogLevel)
-	if err != nil {
+	if err := c.exec(args); err != nil {
 		return err
 	}
-	logrus.SetLevel(level)
-
 	logrus.Debugf("reading file: %s", c.Args.File)
 	content, err := ioutil.ReadFile(c.Args.File)
 	if err != nil {

--- a/cmd/bblfsh/common.go
+++ b/cmd/bblfsh/common.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/Sirupsen/logrus"
+)
+
+type commonCmd struct {
+	LogLevel    string `long:"log-level" description:"log level" default:"debug"`
+}
+
+func (c *commonCmd) exec(args []string) error {
+	level, err := logrus.ParseLevel(c.LogLevel)
+	if err != nil {
+		return err
+	}
+	logrus.SetLevel(level)
+	return nil
+}
+

--- a/cmd/bblfsh/server.go
+++ b/cmd/bblfsh/server.go
@@ -10,19 +10,16 @@ import (
 )
 
 type serverCmd struct {
+	commonCmd
 	Address     string `long:"address" description:"server address to bind to" default:"0.0.0.0:9432"`
 	RuntimePath string `long:"runtime-path" description:"runtime path" default:"/tmp/bblfsh-runtime"`
 	Transport   string `long:"transport" description:"default transport to fetch driver images (docker, docker-daemon)" default:"docker"`
-	LogLevel    string `long:"log-level" description:"log level" default:"debug"`
 }
 
 func (c *serverCmd) Execute(args []string) error {
-	level, err := logrus.ParseLevel(c.LogLevel)
-	if err != nil {
+	if err := c.exec(args); err != nil {
 		return err
 	}
-	logrus.SetLevel(level)
-
 	logrus.Debugf("binding to %s", c.Address)
 	//TODO: add support for unix://
 	lis, err := net.Listen("tcp", c.Address)

--- a/cmd/bblfsh/server.go
+++ b/cmd/bblfsh/server.go
@@ -13,9 +13,16 @@ type serverCmd struct {
 	Address     string `long:"address" description:"server address to bind to" default:"0.0.0.0:9432"`
 	RuntimePath string `long:"runtime-path" description:"runtime path" default:"/tmp/bblfsh-runtime"`
 	Transport   string `long:"transport" description:"default transport to fetch driver images (docker, docker-daemon)" default:"docker"`
+	LogLevel    string `long:"log-level" description:"log level" default:"debug"`
 }
 
 func (c *serverCmd) Execute(args []string) error {
+	level, err := logrus.ParseLevel(c.LogLevel)
+	if err != nil {
+		return err
+	}
+	logrus.SetLevel(level)
+
 	logrus.Debugf("binding to %s", c.Address)
 	//TODO: add support for unix://
 	lis, err := net.Listen("tcp", c.Address)


### PR DESCRIPTION
This solves #33 
Note that the code between client and server is duplicated, but there're already some duplicated options. I think we should add some CommonCmd for these, what do you think?