### PR TITLE
Add support for the encoding parameter in the client

### DIFF
--- a/cmd/bblfsh/client.go
+++ b/cmd/bblfsh/client.go
@@ -23,6 +23,7 @@ type clientCmd struct {
 	RuntimePath string `long:"runtime-path" description:"runtime path for standalone mode" default:"/tmp/bblfsh-runtime"`
 	ImageRef    string `long:"image" value-name:"image-ref" description:"image reference to use (e.g. docker://bblfsh/python-driver:latest)"`
 	Language    string `long:"language" description:"language of the input" default:""`
+	Encoding    string `long:"encoding" description:"encoding used in the source file" default:"UTF8"`
 	Args        struct {
 		File string `positional-arg-name:"file" required:"true"`
 	} `positional-args:"yes"`
@@ -43,10 +44,19 @@ func (c *clientCmd) Execute(args []string) error {
 		run = c.runStandalone
 	}
 
+	var encoding protocol.Encoding
+	switch(c.Encoding) {
+	case "Base64":
+		encoding = protocol.Base64
+	default:
+		encoding = protocol.UTF8
+	}
+
 	req := &protocol.ParseUASTRequest{
 		Filename: filepath.Base(c.Args.File),
 		Language: c.Language,
 		Content:  string(content),
+		Encoding: encoding,
 	}
 	resp, err := run(req)
 	if err != nil {

--- a/glide.lock
+++ b/glide.lock
@@ -2,7 +2,7 @@ hash: 2ec441c21b943409fd526ce520a5b5dfca7b1d890393e611c5ff423dab2ee2b2
 updated: 2017-05-31T10:22:09.845434264+02:00
 imports:
 - name: github.com/bblfsh/sdk
-  version: eeee1c1d6e171616c4027c3f3d748c2872e9f082
+  version: f2aa0ad34ca9190bc515704822c48e51ce05dbc9
   subpackages:
   - manifest
   - protocol


### PR DESCRIPTION
Same as the reviewed and approved bblfsh/server/pull/35 but with the glide.lock fix so Travis doesn't fail on `make dependencies`.
