### PR TITLE
images: Add support to override the image to use per language

### DIFF
--- a/cmd/bblfsh/server.go
+++ b/cmd/bblfsh/server.go
@@ -43,7 +43,10 @@ func (c *serverCmd) Execute(args []string) error {
 		if len(fields) != 2 {
 			return ErrInvalidDriverFormat.New(img)
 		}
-		overrides[strings.TrimSpace(fields[0])] = strings.TrimSpace(fields[1])
+		lang := strings.TrimSpace(fields[0])
+		image := strings.TrimSpace(fields[1])
+		logrus.Debugf("Overriding image for %s: %s", lang, image)
+		overrides[lang] = image
 	}
 	if c.REST {
 		return c.serveREST(r, overrides)

--- a/cmd/bblfsh/server.go
+++ b/cmd/bblfsh/server.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	errors "srcd.works/go-errors.v0"
+	"srcd.works/go-errors.v0"
 
 	"github.com/bblfsh/server"
 	"github.com/bblfsh/server/runtime"
@@ -48,6 +48,7 @@ func (c *serverCmd) Execute(args []string) error {
 		logrus.Debugf("Overriding image for %s: %s", lang, image)
 		overrides[lang] = image
 	}
+
 	if c.REST {
 		return c.serveREST(r, overrides)
 	}

--- a/common.go
+++ b/common.go
@@ -10,7 +10,10 @@ const (
 
 // DefaultDriverImageReference returns the default image reference for a driver
 // given a language.
-func DefaultDriverImageReference(transport, lang string) string {
+func DefaultDriverImageReference(overrides map[string]string, transport, lang string) string {
+	if override := overrides[lang]; override != "" {
+		return override
+	}
 	if transport == "" {
 		transport = DefaultTransport
 	}

--- a/common_test.go
+++ b/common_test.go
@@ -14,7 +14,12 @@ func init() {
 func TestDefaultDriverImageReference(t *testing.T) {
 	require := require.New(t)
 
-	require.Equal("docker://bblfsh/python-driver:latest", DefaultDriverImageReference("docker", "python"))
-	require.Equal("docker://bblfsh/python-driver:latest", DefaultDriverImageReference("", "python"))
-	require.Equal("docker-daemon:bblfsh/python-driver:latest", DefaultDriverImageReference("docker-daemon", "python"))
+	no_overrides := make(map[string]string)
+	python_override := make(map[string]string)
+	python_override["python"] = "overriden"
+
+	require.Equal("docker://bblfsh/python-driver:latest", DefaultDriverImageReference(no_overrides, "docker", "python"))
+	require.Equal("docker://bblfsh/python-driver:latest", DefaultDriverImageReference(no_overrides, "", "python"))
+	require.Equal("docker-daemon:bblfsh/python-driver:latest", DefaultDriverImageReference(no_overrides, "docker-daemon", "python"))
+	require.Equal("overriden", DefaultDriverImageReference(python_override, "docker-daemon", "python"))
 }

--- a/grpc.go
+++ b/grpc.go
@@ -13,8 +13,8 @@ type GRPCServer struct {
 	*Server
 }
 
-func NewGRPCServer(r *runtime.Runtime, transport string) *GRPCServer {
-	server := NewServer(r)
+func NewGRPCServer(r *runtime.Runtime, overrides map[string]string, transport string) *GRPCServer {
+	server := NewServer(r, overrides)
 	server.Transport = transport
 	return &GRPCServer{server}
 }

--- a/rest.go
+++ b/rest.go
@@ -16,8 +16,8 @@ type RESTServer struct {
 	*Server
 }
 
-func NewRESTServer(r *runtime.Runtime, transport string) *RESTServer {
-	server := NewServer(r)
+func NewRESTServer(r *runtime.Runtime, overrides map[string]string, transport string) *RESTServer {
+	server := NewServer(r, overrides)
 	server.Transport = transport
 	return &RESTServer{server}
 }

--- a/rest_test.go
+++ b/rest_test.go
@@ -27,7 +27,7 @@ func TestRestServerParse(t *testing.T) {
 	err = r.Init()
 	require.NoError(err)
 
-	s := NewServer(r)
+	s := NewServer(r, make(map[string]string))
 	dp, err := StartDriverPool(DefaultScalingPolicy(), DefaultPoolTimeout, func() (Driver, error) {
 		return &echoDriver{}, nil
 	})

--- a/server.go
+++ b/server.go
@@ -25,12 +25,14 @@ type Server struct {
 	rt        *runtime.Runtime
 	mu        sync.RWMutex
 	drivers   map[string]Driver
+	overrides map[string]string // Overrides for images per language
 }
 
-func NewServer(r *runtime.Runtime) *Server {
+func NewServer(r *runtime.Runtime, overrides map[string]string) *Server {
 	return &Server{
-		rt:      r,
-		drivers: make(map[string]Driver),
+		rt:        r,
+		drivers:   make(map[string]Driver),
+		overrides: overrides,
 	}
 }
 
@@ -67,7 +69,7 @@ func (s *Server) Driver(lang string) (Driver, error) {
 	d, ok := s.drivers[lang]
 	s.mu.RUnlock()
 	if !ok {
-		img := DefaultDriverImageReference(s.Transport, lang)
+		img := DefaultDriverImageReference(s.overrides, s.Transport, lang)
 		err := s.AddDriver(lang, img)
 		if err != nil && !ErrAlreadyInstalled.Is(err) {
 			return nil, ErrMissingDriver.Wrap(err, lang)

--- a/server_test.go
+++ b/server_test.go
@@ -45,7 +45,7 @@ func TestNewServerMockedDriverParallelClients(t *testing.T) {
 	err = r.Init()
 	require.NoError(err)
 
-	s := NewServer(r)
+	s := NewServer(r, make(map[string]string))
 	dp, err := StartDriverPool(DefaultScalingPolicy(), DefaultPoolTimeout, func() (Driver, error) {
 		return &echoDriver{}, nil
 	})


### PR DESCRIPTION
Fixes #43 
I used a slightly different environment variable name which I think may be better.
I also preferred to handle the environment in the same place where CLI inputs are handled, and pass this information to the server explicitely.