### PR TITLE
Fix build failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ build-internal:
 	mkdir -p $(BUILD_PATH); \
 	for cmd in $(COMMANDS); do \
         cd $(CMD_PATH)/$${cmd}; \
-		$(GO_CMD) build --ldflags '$(LDFLAGS)' -o $(BUILD_PATH)/$${cmd} .; \
+		$(GO_CMD) build -a --ldflags '$(LDFLAGS)' -o $(BUILD_PATH)/$${cmd} .; \
 	done;
 
 docker-image-build: build


### PR DESCRIPTION
This is an attempt to address #29 

There are 2 possible fixes so far
 - add `-a` to `go build`
 - ~add `CGO_ENABLED=0`~ `libcontainer` seems to fail the build without it

Let me know if there are other ways to fix it and I will be happy to update PR.