### PR TITLE
Revert to go 1.7 to fix travis builds

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine
+FROM golang:1.7-alpine
 
 RUN apk add --no-cache git make musl-dev musl-utils gcc lvm2-dev btrfs-progs-dev
 ENV GOPATH=/go


### PR DESCRIPTION
It seems that the linking problem is related to go 1.8.3. It appeared also on travis builds. I've switched to go 1.7 in alpine