### PR TITLE
Add a --max-message-size CLI option for both client and server

### DIFF
--- a/cmd/bblfsh/client.go
+++ b/cmd/bblfsh/client.go
@@ -33,6 +33,7 @@ func (c *clientCmd) Execute(args []string) error {
 	if err := c.exec(args); err != nil {
 		return err
 	}
+
 	logrus.Debugf("reading file: %s", c.Args.File)
 	content, err := ioutil.ReadFile(c.Args.File)
 	if err != nil {
@@ -68,8 +69,19 @@ func (c *clientCmd) Execute(args []string) error {
 }
 
 func (c *clientCmd) runClient(req *protocol.ParseUASTRequest) (*protocol.ParseUASTResponse, error) {
+	maxMessageSize, err := c.parseMaxMessageSize()
+	if err != nil {
+		return nil, err
+	}
+
+	callOptions := []grpc.CallOption{}
+	if maxMessageSize != 0 {
+		callOptions = append(callOptions, grpc.MaxCallRecvMsgSize(maxMessageSize))
+		callOptions = append(callOptions, grpc.MaxCallSendMsgSize(maxMessageSize))
+	}
+
 	logrus.Debugf("dialing server at %s", c.Address)
-	conn, err := grpc.Dial(c.Address, grpc.WithInsecure())
+	conn, err := grpc.Dial(c.Address, grpc.WithInsecure(), grpc.WithDefaultCallOptions(callOptions...))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/bblfsh/client.go
+++ b/cmd/bblfsh/client.go
@@ -45,7 +45,7 @@ func (c *clientCmd) Execute(args []string) error {
 	}
 
 	var encoding protocol.Encoding
-	switch(c.Encoding) {
+	switch c.Encoding {
 	case "Base64":
 		encoding = protocol.Base64
 	default:

--- a/cmd/bblfsh/common.go
+++ b/cmd/bblfsh/common.go
@@ -1,11 +1,19 @@
 package main
 
 import (
+	"strconv"
+
 	"github.com/Sirupsen/logrus"
+	"gopkg.in/src-d/go-errors.v0"
+)
+
+var (
+	ErrMaxMessageSizeTooBig = errors.NewKind("max-message-size too big (limit is 2047MB): %u")
 )
 
 type commonCmd struct {
-	LogLevel    string `long:"log-level" description:"log level" default:"debug"`
+	LogLevel       string `long:"log-level" description:"log level" default:"debug"`
+	MaxMessageSize string `long:"max-message-size" description:"maximum message size to send/receive to/from clients (in MB)" default:""`
 }
 
 func (c *commonCmd) exec(args []string) error {
@@ -17,3 +25,21 @@ func (c *commonCmd) exec(args []string) error {
 	return nil
 }
 
+func (c *commonCmd) parseMaxMessageSize() (int, error) {
+	if c.MaxMessageSize == "" {
+		return 0, nil
+	}
+
+	n, err := strconv.ParseUint(c.MaxMessageSize, 10, 16)
+	if err != nil {
+		return 0, err
+	}
+
+	if n >= 2048 {
+		// Setting the hard limit of message size to less than 2GB since
+		// it may overflow an int value, and it should be big enough
+		return 0, ErrMaxMessageSizeTooBig.New(n)
+	}
+
+	return int(n * 1024 * 1024), nil // Convert MB to B
+}

--- a/cmd/bblfsh/server.go
+++ b/cmd/bblfsh/server.go
@@ -68,13 +68,18 @@ func (c *serverCmd) serveREST(r *runtime.Runtime, overrides map[string]string) e
 }
 
 func (c *serverCmd) serveGRPC(r *runtime.Runtime, overrides map[string]string) error {
+	maxMessageSize, err := c.parseMaxMessageSize()
+	if err != nil {
+		return err
+	}
+
 	//TODO: add support for unix://
 	lis, err := net.Listen("tcp", c.Address)
 	if err != nil {
 		return err
 	}
 
-	s := server.NewGRPCServer(r, overrides, c.Transport)
+	s := server.NewGRPCServer(r, overrides, c.Transport, maxMessageSize)
 
 	logrus.Debug("starting server")
 	return s.Serve(lis)

--- a/server_test.go
+++ b/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -16,6 +17,8 @@ import (
 	"github.com/bblfsh/sdk/uast"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type echoDriver struct{}
@@ -112,4 +115,172 @@ func TestDefaultDriverImageReference(t *testing.T) {
 	s = NewServer(r, python_override)
 	s.Transport = "docker-daemon"
 	require.Equal("overriden", s.defaultDriverImageReference("python"))
+}
+
+func TestMaxMessageSizeExceeded(t *testing.T) {
+	require := require.New(t)
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "bblfsh-runtime")
+	r := runtime.NewRuntime(tmpDir)
+	err = r.Init()
+	require.NoError(err)
+
+	s := NewServer(r, make(map[string]string))
+	dp, err := StartDriverPool(DefaultScalingPolicy(), DefaultPoolTimeout, func() (Driver, error) {
+		return &echoDriver{}, nil
+	})
+	require.NoError(err)
+	require.NotNil(dp)
+
+	s.drivers["python"] = dp
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(err)
+	go (&GRPCServer{s, []grpc.ServerOption{}}).Serve(lis)
+
+	time.Sleep(time.Second * 1)
+
+	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithInsecure(), grpc.WithTimeout(time.Second*2))
+	require.NoError(err)
+	client := protocol.NewProtocolServiceClient(conn)
+	_, err = client.ParseUAST(context.TODO(), &protocol.ParseUASTRequest{Content: bigContent()})
+	require.NotNil(err)
+	status, _ := status.FromError(err)
+	require.Equal(status.Code(), codes.ResourceExhausted)
+	err = conn.Close()
+	require.NoError(err)
+	err = s.Close()
+	require.NoError(err)
+}
+
+func TestMaxMessageSizeExceededInClient(t *testing.T) {
+	require := require.New(t)
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "bblfsh-runtime")
+	r := runtime.NewRuntime(tmpDir)
+	err = r.Init()
+	require.NoError(err)
+
+	s := NewServer(r, make(map[string]string))
+	dp, err := StartDriverPool(DefaultScalingPolicy(), DefaultPoolTimeout, func() (Driver, error) {
+		return &echoDriver{}, nil
+	})
+	require.NoError(err)
+	require.NotNil(dp)
+
+	s.drivers["python"] = dp
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(err)
+	serverOptions := []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(8 * 1024 * 1024),
+		grpc.MaxSendMsgSize(8 * 1024 * 1024)}
+
+	go (&GRPCServer{s, serverOptions}).Serve(lis)
+
+	time.Sleep(time.Second * 1)
+
+	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithInsecure(), grpc.WithTimeout(time.Second*2))
+	require.NoError(err)
+	client := protocol.NewProtocolServiceClient(conn)
+	_, err = client.ParseUAST(context.TODO(), &protocol.ParseUASTRequest{Content: bigContent()})
+	require.NotNil(err)
+	status, _ := status.FromError(err)
+	require.Equal(status.Code(), codes.ResourceExhausted)
+	err = conn.Close()
+	require.NoError(err)
+	err = s.Close()
+	require.NoError(err)
+}
+
+func TestMaxMessageSizeExceededInServer(t *testing.T) {
+	require := require.New(t)
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "bblfsh-runtime")
+	r := runtime.NewRuntime(tmpDir)
+	err = r.Init()
+	require.NoError(err)
+
+	s := NewServer(r, make(map[string]string))
+	dp, err := StartDriverPool(DefaultScalingPolicy(), DefaultPoolTimeout, func() (Driver, error) {
+		return &echoDriver{}, nil
+	})
+	require.NoError(err)
+	require.NotNil(dp)
+
+	s.drivers["python"] = dp
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(err)
+	go (&GRPCServer{s, []grpc.ServerOption{}}).Serve(lis)
+
+	time.Sleep(time.Second * 1)
+
+	callOptions := []grpc.CallOption{
+		grpc.MaxCallRecvMsgSize(8 * 1024 * 1024),
+		grpc.MaxCallSendMsgSize(8 * 1024 * 1024)}
+	conn, err := grpc.Dial(
+		lis.Addr().String(),
+		grpc.WithInsecure(),
+		grpc.WithTimeout(time.Second*2),
+		grpc.WithDefaultCallOptions(callOptions...))
+	require.NoError(err)
+	client := protocol.NewProtocolServiceClient(conn)
+	_, err = client.ParseUAST(context.TODO(), &protocol.ParseUASTRequest{Content: bigContent()})
+	require.NotNil(err)
+	status, _ := status.FromError(err)
+	require.Equal(status.Code(), codes.ResourceExhausted)
+	err = conn.Close()
+	require.NoError(err)
+	err = s.Close()
+	require.NoError(err)
+}
+
+func TestMaxMessageSizeNotExceeded(t *testing.T) {
+	require := require.New(t)
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "bblfsh-runtime")
+	r := runtime.NewRuntime(tmpDir)
+	err = r.Init()
+	require.NoError(err)
+
+	s := NewServer(r, make(map[string]string))
+	dp, err := StartDriverPool(DefaultScalingPolicy(), DefaultPoolTimeout, func() (Driver, error) {
+		return &echoDriver{}, nil
+	})
+	require.NoError(err)
+	require.NotNil(dp)
+
+	s.drivers["python"] = dp
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(err)
+	serverOptions := []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(8 * 1024 * 1024),
+		grpc.MaxSendMsgSize(8 * 1024 * 1024)}
+	go (&GRPCServer{s, serverOptions}).Serve(lis)
+
+	time.Sleep(time.Second * 1)
+
+	callOptions := []grpc.CallOption{
+		grpc.MaxCallRecvMsgSize(8 * 1024 * 1024),
+		grpc.MaxCallSendMsgSize(8 * 1024 * 1024)}
+	conn, err := grpc.Dial(
+		lis.Addr().String(),
+		grpc.WithInsecure(),
+		grpc.WithTimeout(time.Second*2),
+		grpc.WithDefaultCallOptions(callOptions...))
+	require.NoError(err)
+	client := protocol.NewProtocolServiceClient(conn)
+	_, err = client.ParseUAST(context.TODO(), &protocol.ParseUASTRequest{Content: bigContent()})
+	require.NoError(err)
+	err = conn.Close()
+	require.NoError(err)
+	err = s.Close()
+	require.NoError(err)
+}
+
+// Generate a string longer than 4MB, which is the default message limit in GRPC
+func bigContent() string {
+	content := bytes.NewBufferString("")
+	for i := 0; i < 65536; i++ {
+		content.WriteString("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	}
+	return content.String()
 }

--- a/server_test.go
+++ b/server_test.go
@@ -56,7 +56,7 @@ func TestNewServerMockedDriverParallelClients(t *testing.T) {
 
 	lis, err := net.Listen("tcp", "localhost:0")
 	require.NoError(err)
-	go (&GRPCServer{s}).Serve(lis)
+	go (&GRPCServer{s, []grpc.ServerOption{}}).Serve(lis)
 
 	time.Sleep(time.Second * 1)
 


### PR DESCRIPTION
Maximum Message size is expressed in MB. Default limit is 4MB. When
limit is defined through this option, it's applied to both directions:
send and receive