### PR TITLE
Add profiler support

### DIFF
--- a/cmd/bblfsh/client.go
+++ b/cmd/bblfsh/client.go
@@ -15,6 +15,12 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/bblfsh/sdk/protocol"
 	"google.golang.org/grpc"
+	"srcd.works/go-errors.v0"
+)
+
+var (
+	// ErrProfiler happens if a profiler fails
+	ErrProfiler = errors.NewKind("Failed to create a % file at %s")
 )
 
 type clientCmd struct {
@@ -37,9 +43,8 @@ func (c *clientCmd) StartCPUProfileMaybe() error {
 	if c.CPUProfile != "" {
 		f, err := os.Create(c.CPUProfile)
 		if err != nil {
-			errFmt := "Failed to create a CpuProfile file at %s, err:%s"
-			logrus.Errorf(errFmt, c.CPUProfile, err)
-			return fmt.Errorf("Failed to create a CpuProfile file at %s, err:%s", c.CPUProfile, err)
+			logrus.Errorf("Failed to create a CpuProfile file at %s, err:%s", c.CPUProfile, err)
+			return ErrProfiler.Wrap(err, "CpuProfile", c.CPUProfile)
 		}
 		c.CPUProfileFile = f
 		logrus.Infof("Start CPU profiling, save to %s", c.CPUProfile)
@@ -60,9 +65,8 @@ func (c *clientCmd) SaveMemProfileMaybe() error {
 	if c.MemProfile != "" {
 		f, err := os.Create(c.MemProfile)
 		if err != nil {
-			errFmt := "Failed to save Heap profile to %s, err:%s"
-			logrus.Errorf(errFmt, c.MemProfile, err)
-			return fmt.Errorf(errFmt, c.MemProfile, err)
+			logrus.Errorf("Failed to save Heap profile to %s, err:%s", c.MemProfile, err)
+			return ErrProfiler.Wrap(err, "MemProfile", c.MemProfile)
 		}
 		logrus.Infof("Save Heap profile to %s", c.MemProfile)
 		pprof.WriteHeapProfile(f)

--- a/cmd/bblfsh/server.go
+++ b/cmd/bblfsh/server.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"net"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"strings"
-
-	"srcd.works/go-errors.v0"
 
 	"github.com/bblfsh/server"
 	"github.com/bblfsh/server/runtime"
 
 	"github.com/Sirupsen/logrus"
+	"srcd.works/go-errors.v0"
 )
 
 var (
@@ -19,10 +20,12 @@ var (
 
 type serverCmd struct {
 	commonCmd
-	Address     string `long:"address" description:"server address to bind to" default:"0.0.0.0:9432"`
-	RuntimePath string `long:"runtime-path" description:"runtime path" default:"/tmp/bblfsh-runtime"`
-	Transport   string `long:"transport" description:"default transport to fetch driver images (docker, docker-daemon)" default:"docker"`
-	REST        bool   `long:"rest" description:"start a JSON REST server instead of a gRPC server"`
+	Address      string `long:"address" description:"server address to bind to" default:"0.0.0.0:9432"`
+	RuntimePath  string `long:"runtime-path" description:"runtime path" default:"/tmp/bblfsh-runtime"`
+	Transport    string `long:"transport" description:"default transport to fetch driver images (docker, docker-daemon)" default:"docker"`
+	REST         bool   `long:"rest" description:"start a JSON REST server instead of a gRPC server"`
+	Profiler     bool   `long:"profiler" description:"start CPU & memeory profiler"`
+	ProfilerAddr string `long:"profiler-address" description:"address to bind profiler to in case of gRPC" default:"0.0.0.0:6062"`
 }
 
 func (c *serverCmd) Execute(args []string) error {
@@ -68,6 +71,7 @@ func (c *serverCmd) serveREST(r *runtime.Runtime, overrides map[string]string) e
 }
 
 func (c *serverCmd) serveGRPC(r *runtime.Runtime, overrides map[string]string) error {
+	c.startProfilingHTTPServerMaybe(c.ProfilerAddr)
 	maxMessageSize, err := c.parseMaxMessageSize()
 	if err != nil {
 		return err
@@ -83,4 +87,16 @@ func (c *serverCmd) serveGRPC(r *runtime.Runtime, overrides map[string]string) e
 
 	logrus.Debug("starting server")
 	return s.Serve(lis)
+}
+
+func (c *serverCmd) startProfilingHTTPServerMaybe(addr string) {
+	if c.Profiler {
+		go func() {
+			logrus.Debugf("Started CPU & Heap profiler at %s", addr)
+			err := http.ListenAndServe(addr, nil)
+			if err != nil {
+				logrus.Warnf("Profiler failed to listen and serve at %s, err: %s", addr, err)
+			}
+		}()
+	}
 }

--- a/cmd/bblfsh/server.go
+++ b/cmd/bblfsh/server.go
@@ -24,8 +24,8 @@ type serverCmd struct {
 	RuntimePath  string `long:"runtime-path" description:"runtime path" default:"/tmp/bblfsh-runtime"`
 	Transport    string `long:"transport" description:"default transport to fetch driver images (docker, docker-daemon)" default:"docker"`
 	REST         bool   `long:"rest" description:"start a JSON REST server instead of a gRPC server"`
-	Profiler     bool   `long:"profiler" description:"start CPU & memeory profiler"`
-	ProfilerAddr string `long:"profiler-address" description:"address to bind profiler to in case of gRPC" default:"0.0.0.0:6062"`
+	Profiler     bool   `long:"profiler" description:"start CPU & memory profiler"`
+	ProfilerAddr string `long:"profiler-address" description:"address to bind profiler to, in case of gRPC" default:"0.0.0.0:6062"`
 }
 
 func (c *serverCmd) Execute(args []string) error {


### PR DESCRIPTION

 ### Client

Profiler support to client, save results to FS

 Test plan:
 - start server as usual `sudo bblfsh server`
 - start client with new flag
   `bblfsh client --cpuprofile ./sample.pprof sample.py`
 - `go tool pprof ./sample.pprof`


 ### Server

Profiler support to server, expose results over HTTP

Test plan:
```
sudo server --profiler
go tool pprof http://localhost:6062/debug/pprof/profile
```

```
sudo server --profiler --rest
go tool pprof http://localhost:6062/debug/pprof/profile
```