### PR TITLE
Improve logging

### DIFF
--- a/cmd/bblfsh/client.go
+++ b/cmd/bblfsh/client.go
@@ -126,12 +126,12 @@ func (c *clientCmd) runClient(req *protocol.ParseRequest) (*protocol.ParseRespon
 
 	callOptions := []grpc.CallOption{}
 	if maxMessageSize != 0 {
-		logrus.Debugf("setting maximum size for sending and receiving messages to %d", maxMessageSize)
+		logrus.Infof("setting maximum size for sending and receiving messages to %d", maxMessageSize)
 		callOptions = append(callOptions, grpc.MaxCallRecvMsgSize(maxMessageSize))
 		callOptions = append(callOptions, grpc.MaxCallSendMsgSize(maxMessageSize))
 	}
 
-	logrus.Debugf("dialing server at %s", c.Address)
+	logrus.Infof("dialing server at %s", c.Address)
 	conn, err := grpc.Dial(c.Address, grpc.WithInsecure(), grpc.WithDefaultCallOptions(callOptions...))
 	if err != nil {
 		return nil, err
@@ -146,7 +146,7 @@ func (c *clientCmd) runClient(req *protocol.ParseRequest) (*protocol.ParseRespon
 
 func (c *clientCmd) runStandalone(req *protocol.ParseRequest) (*protocol.ParseResponse, error) {
 	r := runtime.NewRuntime(c.RuntimePath)
-	logrus.Debugf("initializing runtime at %s", c.RuntimePath)
+	logrus.Infof("initializing runtime at %s", c.RuntimePath)
 	if err := r.Init(); err != nil {
 		return nil, err
 	}

--- a/cmd/bblfsh/common.go
+++ b/cmd/bblfsh/common.go
@@ -12,7 +12,7 @@ var (
 )
 
 type commonCmd struct {
-	LogLevel       string `long:"log-level" description:"log level" default:"debug"`
+	LogLevel       string `long:"log-level" description:"log level" default:"info"`
 	MaxMessageSize string `long:"max-message-size" description:"maximum message size to send/receive to/from clients (in MB)" default:"100"`
 }
 

--- a/cmd/bblfsh/server.go
+++ b/cmd/bblfsh/server.go
@@ -32,10 +32,10 @@ func (c *serverCmd) Execute(args []string) error {
 	if err := c.exec(args); err != nil {
 		return err
 	}
-	logrus.Debugf("binding to %s", c.Address)
+	logrus.Infof("binding to %s", c.Address)
 
 	r := runtime.NewRuntime(c.RuntimePath)
-	logrus.Debugf("initializing runtime at %s", c.RuntimePath)
+	logrus.Infof("initializing runtime at %s", c.RuntimePath)
 	if err := r.Init(); err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func (c *serverCmd) Execute(args []string) error {
 
 		lang := strings.TrimSpace(fields[0])
 		image := strings.TrimSpace(fields[1])
-		logrus.Debugf("Overriding image for %s: %s", lang, image)
+		logrus.Infof("Overriding image for %s: %s", lang, image)
 		overrides[lang] = image
 	}
 
@@ -92,7 +92,7 @@ func (c *serverCmd) serveGRPC(r *runtime.Runtime, overrides map[string]string) e
 func (c *serverCmd) startProfilingHTTPServerMaybe(addr string) {
 	if c.Profiler {
 		go func() {
-			logrus.Debugf("Started CPU & Heap profiler at %s", addr)
+			logrus.Infof("Started CPU & Heap profiler at %s", addr)
 			err := http.ListenAndServe(addr, nil)
 			if err != nil {
 				logrus.Warnf("Profiler failed to listen and serve at %s, err: %s", addr, err)

--- a/driver.go
+++ b/driver.go
@@ -56,7 +56,7 @@ func ExecDriver(r *runtime.Runtime, img runtime.DriverImage) (Driver, error) {
 		_ = errr.Close()
 		return nil, err
 	}
-	logrus.Debugf("container started %s (%s)", img.Name(), c.ID())
+	logrus.Infof("container started %s (%s)", img.Name(), c.ID())
 
 	go func() {
 		if err := c.Wait(); err != nil {
@@ -75,6 +75,7 @@ type loggingDriver struct {
 }
 
 func (d loggingDriver) Parse(req *protocol.ParseRequest) *protocol.ParseResponse {
-	logrus.Debugf("sending Parse request: %s", req.String())
+	logrus.Infof("parsing %s (%d bytes)", req.Filename, len(req.Content))
+	logrus.Debugf("parse request: %s", req.String())
 	return d.Driver.Parse(req)
 }

--- a/grpc.go
+++ b/grpc.go
@@ -20,7 +20,7 @@ func NewGRPCServer(r *runtime.Runtime, overrides map[string]string, transport st
 
 	opts := []grpc.ServerOption{}
 	if maxMessageSize != 0 {
-		logrus.Debugf("setting maximum size for sending and receiving messages to %d", maxMessageSize)
+		logrus.Infof("setting maximum size for sending and receiving messages to %d", maxMessageSize)
 		opts = append(opts, grpc.MaxRecvMsgSize(maxMessageSize))
 		opts = append(opts, grpc.MaxSendMsgSize(maxMessageSize))
 	}


### PR DESCRIPTION
Try to categorize log messages better:
* Move level from `info` to `debug` in some messages, leaving `debug` really for debugging information
* Set `info` as default log level.

Attempts to solve #75 