### PR TITLE
Use mainstream runc again now that PR opencontainers/runc/pull/1506 is merged

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -147,8 +147,7 @@ imports:
   - specs-go
   - specs-go/v1
 - name: github.com/opencontainers/runc
-  repo: https://github.com/bblfsh/runc.git
-  version: 0d21c2183e3908caff242fe298592b6cc4bf361b
+  version: 7d66aab77abfdd8e2893eb70647fd941f26091b1
   subpackages:
   - libcontainer
   - libcontainer/apparmor

--- a/glide.yaml
+++ b/glide.yaml
@@ -31,8 +31,7 @@ import:
   subpackages:
   - specs-go/v1
 - package: github.com/opencontainers/runc
-  repo: https://github.com/bblfsh/runc.git
-  version: 0d21c2183e3908caff242fe298592b6cc4bf361b
+  version: 7d66aab77abfdd8e2893eb70647fd941f26091b1
   subpackages:
   - libcontainer
   - libcontainer/configs


### PR DESCRIPTION
- Restored to the ~master branch of opencontainers.
- Tested that it doesn't leave zombie processes.

We should also delete out [fork](https://github.com/bblfsh/runc) once a new docker image of the server is published.