### PR TITLE
[Do not merge] Upgrade to SDK v1

### DIFF
--- a/cmd/bblfsh/client.go
+++ b/cmd/bblfsh/client.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"google.golang.org/grpc"
-	"gopkg.in/bblfsh/sdk.v0/protocol"
+	"gopkg.in/bblfsh/sdk.v1/protocol"
 	"gopkg.in/src-d/go-errors.v1"
 )
 

--- a/driver.go
+++ b/driver.go
@@ -7,8 +7,8 @@ import (
 	"github.com/bblfsh/server/runtime"
 
 	"github.com/Sirupsen/logrus"
-	"gopkg.in/bblfsh/sdk.v0/protocol"
-	"gopkg.in/bblfsh/sdk.v0/protocol/driver"
+	"gopkg.in/bblfsh/sdk.v1/protocol"
+	"gopkg.in/bblfsh/sdk.v1/protocol/driver"
 )
 
 // Driver is a client to communicate with a driver. It provides the parser

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c1fadd1102d193acbc8a4e15baa718ce6e9f8bc2c3924d24f19ae74e053d9a9d
-updated: 2017-09-12T17:47:37.472766713+02:00
+hash: daad342484368196eb56a4b47414780ef571e4e53884c74a941dddcdcbf1d639
+updated: 2017-09-14T18:29:14.801683374+02:00
 imports:
 - name: github.com/BurntSushi/toml
   version: a368813c5e648fee92e5f6c30e3944ff9d5e8895
@@ -231,8 +231,8 @@ imports:
   - status
   - tap
   - transport
-- name: gopkg.in/bblfsh/sdk.v0
-  version: 63a5c96d2d00e2b76932f26459d089e0bcbf5835
+- name: gopkg.in/bblfsh/sdk.v1
+  version: b04b0f398c559ab6f626aaf23a5d9606f36cc6be
   subpackages:
   - manifest
   - protocol

--- a/glide.yaml
+++ b/glide.yaml
@@ -36,8 +36,8 @@ import:
   version: ^1.1.0
 - package: google.golang.org/grpc
   version: ^1.4.2
-- package: gopkg.in/bblfsh/sdk.v0
-  version: ^0.2.1
+- package: gopkg.in/bblfsh/sdk.v1
+  version: ^1.0.0-rc1
 - package: gopkg.in/src-d/enry.v1
   version: ^1.3.0
 - package: gopkg.in/src-d/go-errors.v1

--- a/pool.go
+++ b/pool.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"gopkg.in/bblfsh/sdk.v0/protocol"
+	"gopkg.in/bblfsh/sdk.v1/protocol"
 )
 
 var (

--- a/pool_test.go
+++ b/pool_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/bblfsh/sdk.v0/protocol"
+	"gopkg.in/bblfsh/sdk.v1/protocol"
 )
 
 type mockDriver struct {

--- a/runtime/common_test.go
+++ b/runtime/common_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/containers/image/types"
-	"gopkg.in/bblfsh/sdk.v0/manifest"
+	"gopkg.in/bblfsh/sdk.v1/manifest"
 )
 
 func init() {

--- a/runtime/storage.go
+++ b/runtime/storage.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"gopkg.in/bblfsh/sdk.v0/manifest"
+	"gopkg.in/bblfsh/sdk.v1/manifest"
 )
 
 var (

--- a/runtime/storage_test.go
+++ b/runtime/storage_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/bblfsh/sdk.v0/manifest"
+	"gopkg.in/bblfsh/sdk.v1/manifest"
 )
 
 func TestStorageInstall(t *testing.T) {

--- a/server.go
+++ b/server.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"google.golang.org/grpc"
-	"gopkg.in/bblfsh/sdk.v0/protocol"
-	"gopkg.in/bblfsh/sdk.v0/uast"
+	"gopkg.in/bblfsh/sdk.v1/protocol"
+	"gopkg.in/bblfsh/sdk.v1/uast"
 	"gopkg.in/src-d/go-errors.v1"
 )
 

--- a/server_test.go
+++ b/server_test.go
@@ -17,8 +17,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"gopkg.in/bblfsh/sdk.v0/protocol"
-	"gopkg.in/bblfsh/sdk.v0/uast"
+	"gopkg.in/bblfsh/sdk.v1/protocol"
+	"gopkg.in/bblfsh/sdk.v1/uast"
 )
 
 type echoDriver struct{}


### PR DESCRIPTION
Upgrades server to use SDK v1, but there's not point of merging this till we have drivers working on v1 aswell (at this point I don't think it's worth the extra work of maintaining different branches).