### PR TITLE
resilience review

### DIFF
--- a/cmd/bblfshd/main.go
+++ b/cmd/bblfshd/main.go
@@ -86,6 +86,9 @@ func buildLogger() server.Logger {
 		os.Exit(1)
 	}
 
+	logrus.SetLevel(logger.(*logrus.Logger).Level)
+	logrus.SetFormatter(logger.(*logrus.Logger).Formatter)
+
 	return logger
 }
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/bblfsh/server/runtime"
+	"github.com/opencontainers/runc/libcontainer"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -164,6 +165,10 @@ func (d *echoDriver) Version(
 
 func (d *echoDriver) Start() error {
 	return nil
+}
+
+func (d *echoDriver) Status() (libcontainer.Status, error) {
+	return libcontainer.Running, nil
 }
 
 func (d *echoDriver) Service() protocol.ProtocolServiceClient {

--- a/daemon/driver.go
+++ b/daemon/driver.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/bblfsh/server/runtime"
 
+	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"google.golang.org/grpc"
 	"gopkg.in/bblfsh/sdk.v1/protocol"
@@ -21,6 +22,7 @@ import (
 type Driver interface {
 	Start() error
 	Stop() error
+	Status() (libcontainer.Status, error)
 	Service() protocol.ProtocolServiceClient
 }
 
@@ -139,6 +141,10 @@ func (i *DriverInstance) loadVersion() error {
 	}
 
 	return nil
+}
+
+func (i *DriverInstance) Status() (libcontainer.Status, error) {
+	return i.Container.Status()
 }
 
 // Stop stops the inner running container.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -104,8 +104,6 @@ func ContainerConfigFactory(containerID string) *configs.Config {
 			{Type: configs.NEWUTS},
 			{Type: configs.NEWIPC},
 			{Type: configs.NEWPID},
-			//{Type: configs.NEWUSER},
-			{Type: configs.NEWNET},
 		}),
 		Cgroups: &configs.Cgroup{
 			Name:   "bblfsh",


### PR DESCRIPTION
I made some stress and also basic tests to the server, and I found some unexpected behaviors. This PRs contains a fix for all of them and also some extra log lines.

The main changes are:
- At container, doesn't try to close anymore the given steams to the container, when `os.Stdout` it try to close, freezing the process and even killing the container parent process.
- At pool, it detects stopped drivers, and prune it from the pool. 