### PR TITLE
bblfshctl: new commands parse and drivers

### DIFF
--- a/cli/bblfshctl/cmd/base.go
+++ b/cli/bblfshctl/cmd/base.go
@@ -7,27 +7,46 @@ import (
 	"github.com/bblfsh/server/daemon/protocol"
 
 	"google.golang.org/grpc"
+	sdk "gopkg.in/bblfsh/sdk.v1/protocol"
 )
 
-type GRPCCommand struct {
-	Network string `long:"endpoint" default:"unix" description:"control server network type"`
-	Address string `long:"address" default:"/var/run/bblfshctl.sock" description:"control server address to connect"`
+type ControlCommand struct {
+	Network string `long:"ctl-endpoint" default:"unix" description:"control server network type"`
+	Address string `long:"ctl-address" default:"/var/run/bblfshctl.sock" description:"control server address to connect"`
 
 	conn *grpc.ClientConn
 	srv  protocol.ProtocolServiceClient
 }
 
-func (c *GRPCCommand) Execute(args []string) error {
-	conn, err := grpc.Dial(c.Address,
+func (c *ControlCommand) Execute(args []string) error {
+	var err error
+	c.conn, err = dialGRPC(c.Network, c.Address)
+	c.srv = protocol.NewProtocolServiceClient(c.conn)
+	return err
+}
+
+type UserCommand struct {
+	Network string `long:"endpoint" default:"tcp" description:"server network type"`
+	Address string `long:"address" default:"localhost:9432" description:"server address to connect"`
+
+	conn *grpc.ClientConn
+	srv  sdk.ProtocolServiceClient
+}
+
+func (c *UserCommand) Execute(args []string) error {
+	var err error
+	c.conn, err = dialGRPC(c.Network, c.Address)
+	c.srv = sdk.NewProtocolServiceClient(c.conn)
+	return err
+}
+
+func dialGRPC(network, address string) (*grpc.ClientConn, error) {
+	return grpc.Dial(address,
 		grpc.WithDialer(func(addr string, t time.Duration) (net.Conn, error) {
-			return net.DialTimeout(c.Network, addr, t)
+			return net.DialTimeout(network, address, t)
 		}),
 		grpc.WithBlock(),
 		grpc.WithTimeout(5*time.Second),
 		grpc.WithInsecure(),
 	)
-
-	c.conn = conn
-	c.srv = protocol.NewProtocolServiceClient(conn)
-	return err
 }

--- a/cli/bblfshctl/cmd/drivers.go
+++ b/cli/bblfshctl/cmd/drivers.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/bblfsh/server/daemon/protocol"
+
+	"github.com/bblfsh/server/runtime"
+	"github.com/docker/go-units"
+	"github.com/olekukonko/tablewriter"
+)
+
+const DriversCommandDescription = "List the installed drivers for each language"
+
+type DriversCommand struct {
+	ControlCommand
+}
+
+func (c *DriversCommand) Execute(args []string) error {
+	if err := c.ControlCommand.Execute(nil); err != nil {
+		return err
+	}
+
+	r, err := c.srv.DriverStates(context.Background(), &protocol.DriverStatesRequest{})
+	if err != nil {
+		return err
+	}
+
+	driverStatusToText(r)
+	return nil
+}
+
+func driverStatusToText(r *protocol.DriverStatesResponse) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Language", "Image", "Version", "Status", "Created", "OS", "Go", "Native"})
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+
+	for _, s := range r.State {
+		var native []string
+		for _, v := range s.NativeVersion {
+			native = append(native, fmt.Sprintf("%s", v))
+		}
+
+		image, _ := runtime.ParseImageName(s.Reference)
+
+		line := fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s",
+			s.Language, image.StringWithinTransport(), s.Version,
+			s.Status, units.HumanDuration(time.Since(s.Build)),
+			s.OS, s.GoVersion, strings.Join(native, ","),
+		)
+		table.Append(strings.Split(line, "\t"))
+	}
+
+	table.Render()
+	fmt.Printf("Response time %s\n", r.Elapsed)
+}

--- a/cli/bblfshctl/cmd/instances.go
+++ b/cli/bblfshctl/cmd/instances.go
@@ -9,17 +9,18 @@ import (
 
 	"github.com/bblfsh/server/daemon/protocol"
 
+	"github.com/docker/go-units"
 	"github.com/olekukonko/tablewriter"
 )
 
-const InstancesCommandDescription = "prints the status for each driver instances running on the daemon."
+const InstancesCommandDescription = "List the driver instances running on the daemon"
 
 type InstancesCommand struct {
-	GRPCCommand
+	ControlCommand
 }
 
 func (c *InstancesCommand) Execute(args []string) error {
-	if err := c.GRPCCommand.Execute(nil); err != nil {
+	if err := c.ControlCommand.Execute(nil); err != nil {
 		return err
 	}
 
@@ -45,8 +46,11 @@ func instancesStatusToText(r *protocol.DriverInstanceStatesResponse) {
 
 		line := fmt.Sprintf("%s\t%s\t%s\t%s\t%s",
 			s.ID[:10], s.Image,
-			s.Status, time.Since(s.Created), pids,
+			s.Status,
+			units.HumanDuration(time.Since(s.Created)),
+			strings.Join(pids, ","),
 		)
+
 		table.Append(strings.Split(line, "\t"))
 	}
 

--- a/cli/bblfshctl/cmd/parse.go
+++ b/cli/bblfshctl/cmd/parse.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"gopkg.in/bblfsh/sdk.v1/protocol"
+
+	"github.com/hokaccha/go-prettyjson"
+)
+
+const ParseCommandDescription = "Parse a file and prints the UAST or AST"
+
+type ParseCommand struct {
+	Args struct {
+		File string `positional-arg-name:"filename" description:"file to parse"`
+	} `positional-args:"yes"`
+
+	Native bool `long:"native" description:"if native, the native AST will be returned"`
+	UserCommand
+}
+
+func (c *ParseCommand) Execute(args []string) error {
+	if err := c.UserCommand.Execute(nil); err != nil {
+		return err
+	}
+
+	if c.Args.File == "" {
+		return fmt.Errorf("file argument is mandatory")
+	}
+
+	content, err := ioutil.ReadFile(c.Args.File)
+	if err != nil {
+		return err
+	}
+
+	if c.Native {
+		return c.doNative(string(content))
+	}
+
+	return c.doUAST(string(content))
+}
+
+func (c *ParseCommand) doUAST(content string) error {
+	resp, err := c.srv.Parse(context.TODO(), &protocol.ParseRequest{
+		Filename: filepath.Base(c.Args.File),
+		Content:  string(content),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	printResponse(&resp.Response)
+	fmt.Println(resp.UAST)
+	return nil
+}
+
+func (c *ParseCommand) doNative(content string) error {
+	resp, err := c.srv.NativeParse(context.TODO(), &protocol.NativeParseRequest{
+		Filename: filepath.Base(c.Args.File),
+		Content:  string(content),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	pp, err := prettyjson.Format([]byte(resp.AST))
+	if err != nil {
+		return err
+	}
+
+	printResponse(&resp.Response)
+	fmt.Println(string(pp))
+	return nil
+}
+
+func printResponse(r *protocol.Response) {
+	fmt.Printf("Status: %s\n", r.Status)
+	fmt.Printf("Elapsed: %s\n", r.Elapsed)
+
+	if len(r.Errors) != 0 {
+		fmt.Println("Errors:")
+		for _, err := range r.Errors {
+			fmt.Printf("\t- %s\n", err)
+		}
+	}
+
+	fmt.Println("")
+}

--- a/cli/bblfshctl/cmd/status.go
+++ b/cli/bblfshctl/cmd/status.go
@@ -11,14 +11,14 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-const StatusCommandDescription = "prints the status for each pool of driver instances running on the daemon."
+const StatusCommandDescription = "List all the pools of driver instances running"
 
 type StatusCommand struct {
-	GRPCCommand
+	ControlCommand
 }
 
 func (c *StatusCommand) Execute(args []string) error {
-	if err := c.GRPCCommand.Execute(nil); err != nil {
+	if err := c.ControlCommand.Execute(nil); err != nil {
 		return err
 	}
 

--- a/cli/bblfshctl/main.go
+++ b/cli/bblfshctl/main.go
@@ -18,11 +18,13 @@ func main() {
 	parser := flags.NewNamedParser("bblfshctl", flags.Default)
 	parser.AddCommand("status", cmd.StatusCommandDescription, "", &cmd.StatusCommand{})
 	parser.AddCommand("instances", cmd.InstancesCommandDescription, "", &cmd.InstancesCommand{})
+	parser.AddCommand("drivers", cmd.DriversCommandDescription, "", &cmd.DriversCommand{})
+	parser.AddCommand("parse", cmd.ParseCommandDescription, "", &cmd.ParseCommand{})
 
 	if _, err := parser.Parse(); err != nil {
 		if _, ok := err.(*flags.Error); ok {
 			parser.WriteHelp(os.Stdout)
-			fmt.Printf("\nBuild information\n  commit: %s\n  date:%s\n", version, build)
+			fmt.Printf("\nBuild information\n  commit: %s\n  date: %s\n", version, build)
 		}
 
 		os.Exit(1)

--- a/daemon/protocol/generated.pb.go
+++ b/daemon/protocol/generated.pb.go
@@ -8,12 +8,15 @@
 		github.com/bblfsh/server/daemon/protocol/generated.proto
 
 	It has these top-level messages:
+		DriverImageState
 		DriverInstanceState
 		DriverInstanceStatesResponse
 		DriverPoolState
 		DriverPoolStatesResponse
+		DriverStatesResponse
 		DriverInstanceStatesRequest
 		DriverPoolStatesRequest
+		DriverStatesRequest
 */
 package protocol
 
@@ -65,29 +68,39 @@ var Status_value = map[string]int32{
 
 func (Status) EnumDescriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{0} }
 
+func (m *DriverImageState) Reset()                    { *m = DriverImageState{} }
+func (m *DriverImageState) String() string            { return proto.CompactTextString(m) }
+func (*DriverImageState) ProtoMessage()               {}
+func (*DriverImageState) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{0} }
+
 func (m *DriverInstanceState) Reset()                    { *m = DriverInstanceState{} }
 func (m *DriverInstanceState) String() string            { return proto.CompactTextString(m) }
 func (*DriverInstanceState) ProtoMessage()               {}
-func (*DriverInstanceState) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{0} }
+func (*DriverInstanceState) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{1} }
 
 func (m *DriverInstanceStatesResponse) Reset()         { *m = DriverInstanceStatesResponse{} }
 func (m *DriverInstanceStatesResponse) String() string { return proto.CompactTextString(m) }
 func (*DriverInstanceStatesResponse) ProtoMessage()    {}
 func (*DriverInstanceStatesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptorGenerated, []int{1}
+	return fileDescriptorGenerated, []int{2}
 }
 
 func (m *DriverPoolState) Reset()                    { *m = DriverPoolState{} }
 func (m *DriverPoolState) String() string            { return proto.CompactTextString(m) }
 func (*DriverPoolState) ProtoMessage()               {}
-func (*DriverPoolState) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{2} }
+func (*DriverPoolState) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{3} }
 
 func (m *DriverPoolStatesResponse) Reset()         { *m = DriverPoolStatesResponse{} }
 func (m *DriverPoolStatesResponse) String() string { return proto.CompactTextString(m) }
 func (*DriverPoolStatesResponse) ProtoMessage()    {}
 func (*DriverPoolStatesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptorGenerated, []int{3}
+	return fileDescriptorGenerated, []int{4}
 }
+
+func (m *DriverStatesResponse) Reset()                    { *m = DriverStatesResponse{} }
+func (m *DriverStatesResponse) String() string            { return proto.CompactTextString(m) }
+func (*DriverStatesResponse) ProtoMessage()               {}
+func (*DriverStatesResponse) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{5} }
 
 type DriverInstanceStatesRequest struct {
 }
@@ -96,7 +109,7 @@ func (m *DriverInstanceStatesRequest) Reset()         { *m = DriverInstanceState
 func (m *DriverInstanceStatesRequest) String() string { return proto.CompactTextString(m) }
 func (*DriverInstanceStatesRequest) ProtoMessage()    {}
 func (*DriverInstanceStatesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptorGenerated, []int{4}
+	return fileDescriptorGenerated, []int{6}
 }
 
 type DriverPoolStatesRequest struct {
@@ -105,15 +118,26 @@ type DriverPoolStatesRequest struct {
 func (m *DriverPoolStatesRequest) Reset()                    { *m = DriverPoolStatesRequest{} }
 func (m *DriverPoolStatesRequest) String() string            { return proto.CompactTextString(m) }
 func (*DriverPoolStatesRequest) ProtoMessage()               {}
-func (*DriverPoolStatesRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{5} }
+func (*DriverPoolStatesRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{7} }
+
+type DriverStatesRequest struct {
+}
+
+func (m *DriverStatesRequest) Reset()                    { *m = DriverStatesRequest{} }
+func (m *DriverStatesRequest) String() string            { return proto.CompactTextString(m) }
+func (*DriverStatesRequest) ProtoMessage()               {}
+func (*DriverStatesRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{8} }
 
 func init() {
+	proto.RegisterType((*DriverImageState)(nil), "github.com.bblfsh.server.daemon.protocol.DriverImageState")
 	proto.RegisterType((*DriverInstanceState)(nil), "github.com.bblfsh.server.daemon.protocol.DriverInstanceState")
 	proto.RegisterType((*DriverInstanceStatesResponse)(nil), "github.com.bblfsh.server.daemon.protocol.DriverInstanceStatesResponse")
 	proto.RegisterType((*DriverPoolState)(nil), "github.com.bblfsh.server.daemon.protocol.DriverPoolState")
 	proto.RegisterType((*DriverPoolStatesResponse)(nil), "github.com.bblfsh.server.daemon.protocol.DriverPoolStatesResponse")
+	proto.RegisterType((*DriverStatesResponse)(nil), "github.com.bblfsh.server.daemon.protocol.DriverStatesResponse")
 	proto.RegisterType((*DriverInstanceStatesRequest)(nil), "github.com.bblfsh.server.daemon.protocol.DriverInstanceStatesRequest")
 	proto.RegisterType((*DriverPoolStatesRequest)(nil), "github.com.bblfsh.server.daemon.protocol.DriverPoolStatesRequest")
+	proto.RegisterType((*DriverStatesRequest)(nil), "github.com.bblfsh.server.daemon.protocol.DriverStatesRequest")
 	proto.RegisterEnum("github.com.bblfsh.server.daemon.protocol.Status", Status_name, Status_value)
 }
 
@@ -130,6 +154,7 @@ const _ = grpc.SupportPackageIsVersion4
 type ProtocolServiceClient interface {
 	DriverInstanceStates(ctx context.Context, in *DriverInstanceStatesRequest, opts ...grpc.CallOption) (*DriverInstanceStatesResponse, error)
 	DriverPoolStates(ctx context.Context, in *DriverPoolStatesRequest, opts ...grpc.CallOption) (*DriverPoolStatesResponse, error)
+	DriverStates(ctx context.Context, in *DriverStatesRequest, opts ...grpc.CallOption) (*DriverStatesResponse, error)
 }
 
 type protocolServiceClient struct {
@@ -158,11 +183,21 @@ func (c *protocolServiceClient) DriverPoolStates(ctx context.Context, in *Driver
 	return out, nil
 }
 
+func (c *protocolServiceClient) DriverStates(ctx context.Context, in *DriverStatesRequest, opts ...grpc.CallOption) (*DriverStatesResponse, error) {
+	out := new(DriverStatesResponse)
+	err := grpc.Invoke(ctx, "/github.com.bblfsh.server.daemon.protocol.ProtocolService/DriverStates", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // Server API for ProtocolService service
 
 type ProtocolServiceServer interface {
 	DriverInstanceStates(context.Context, *DriverInstanceStatesRequest) (*DriverInstanceStatesResponse, error)
 	DriverPoolStates(context.Context, *DriverPoolStatesRequest) (*DriverPoolStatesResponse, error)
+	DriverStates(context.Context, *DriverStatesRequest) (*DriverStatesResponse, error)
 }
 
 func RegisterProtocolServiceServer(s *grpc.Server, srv ProtocolServiceServer) {
@@ -205,6 +240,24 @@ func _ProtocolService_DriverPoolStates_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ProtocolService_DriverStates_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DriverStatesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ProtocolServiceServer).DriverStates(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/github.com.bblfsh.server.daemon.protocol.ProtocolService/DriverStates",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ProtocolServiceServer).DriverStates(ctx, req.(*DriverStatesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _ProtocolService_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "github.com.bblfsh.server.daemon.protocol.ProtocolService",
 	HandlerType: (*ProtocolServiceServer)(nil),
@@ -217,9 +270,90 @@ var _ProtocolService_serviceDesc = grpc.ServiceDesc{
 			MethodName: "DriverPoolStates",
 			Handler:    _ProtocolService_DriverPoolStates_Handler,
 		},
+		{
+			MethodName: "DriverStates",
+			Handler:    _ProtocolService_DriverStates_Handler,
+		},
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "github.com/bblfsh/server/daemon/protocol/generated.proto",
+}
+
+func (m *DriverImageState) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DriverImageState) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Reference) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintGenerated(dAtA, i, uint64(len(m.Reference)))
+		i += copy(dAtA[i:], m.Reference)
+	}
+	if len(m.Language) > 0 {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintGenerated(dAtA, i, uint64(len(m.Language)))
+		i += copy(dAtA[i:], m.Language)
+	}
+	if len(m.Version) > 0 {
+		dAtA[i] = 0x1a
+		i++
+		i = encodeVarintGenerated(dAtA, i, uint64(len(m.Version)))
+		i += copy(dAtA[i:], m.Version)
+	}
+	dAtA[i] = 0x22
+	i++
+	i = encodeVarintGenerated(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Build)))
+	n1, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Build, dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n1
+	if len(m.Status) > 0 {
+		dAtA[i] = 0x2a
+		i++
+		i = encodeVarintGenerated(dAtA, i, uint64(len(m.Status)))
+		i += copy(dAtA[i:], m.Status)
+	}
+	if len(m.OS) > 0 {
+		dAtA[i] = 0x32
+		i++
+		i = encodeVarintGenerated(dAtA, i, uint64(len(m.OS)))
+		i += copy(dAtA[i:], m.OS)
+	}
+	if len(m.NativeVersion) > 0 {
+		for _, s := range m.NativeVersion {
+			dAtA[i] = 0x3a
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
+	if len(m.GoVersion) > 0 {
+		dAtA[i] = 0x42
+		i++
+		i = encodeVarintGenerated(dAtA, i, uint64(len(m.GoVersion)))
+		i += copy(dAtA[i:], m.GoVersion)
+	}
+	return i, nil
 }
 
 func (m *DriverInstanceState) Marshal() (dAtA []byte, err error) {
@@ -257,28 +391,28 @@ func (m *DriverInstanceState) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintGenerated(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Created)))
-	n1, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
+	n2, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n1
+	i += n2
 	if len(m.Processes) > 0 {
-		dAtA3 := make([]byte, len(m.Processes)*10)
-		var j2 int
+		dAtA4 := make([]byte, len(m.Processes)*10)
+		var j3 int
 		for _, num1 := range m.Processes {
 			num := uint64(num1)
 			for num >= 1<<7 {
-				dAtA3[j2] = uint8(uint64(num)&0x7f | 0x80)
+				dAtA4[j3] = uint8(uint64(num)&0x7f | 0x80)
 				num >>= 7
-				j2++
+				j3++
 			}
-			dAtA3[j2] = uint8(num)
-			j2++
+			dAtA4[j3] = uint8(num)
+			j3++
 		}
 		dAtA[i] = 0x2a
 		i++
-		i = encodeVarintGenerated(dAtA, i, uint64(j2))
-		i += copy(dAtA[i:], dAtA3[:j2])
+		i = encodeVarintGenerated(dAtA, i, uint64(j3))
+		i += copy(dAtA[i:], dAtA4[:j3])
 	}
 	return i, nil
 }
@@ -316,11 +450,11 @@ func (m *DriverInstanceStatesResponse) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintGenerated(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdDuration(m.Elapsed)))
-	n4, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Elapsed, dAtA[i:])
+	n5, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Elapsed, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n4
+	i += n5
 	if len(m.State) > 0 {
 		for _, msg := range m.State {
 			dAtA[i] = 0x1a
@@ -417,11 +551,11 @@ func (m *DriverPoolStatesResponse) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintGenerated(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdDuration(m.Elapsed)))
-	n5, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Elapsed, dAtA[i:])
+	n6, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Elapsed, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n5
+	i += n6
 	if len(m.State) > 0 {
 		for k, _ := range m.State {
 			dAtA[i] = 0x1a
@@ -442,12 +576,65 @@ func (m *DriverPoolStatesResponse) MarshalTo(dAtA []byte) (int, error) {
 				dAtA[i] = 0x12
 				i++
 				i = encodeVarintGenerated(dAtA, i, uint64(v.ProtoSize()))
-				n6, err := v.MarshalTo(dAtA[i:])
+				n7, err := v.MarshalTo(dAtA[i:])
 				if err != nil {
 					return 0, err
 				}
-				i += n6
+				i += n7
 			}
+		}
+	}
+	return i, nil
+}
+
+func (m *DriverStatesResponse) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DriverStatesResponse) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Errors) > 0 {
+		for _, s := range m.Errors {
+			dAtA[i] = 0xa
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
+	dAtA[i] = 0x12
+	i++
+	i = encodeVarintGenerated(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdDuration(m.Elapsed)))
+	n8, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Elapsed, dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n8
+	if len(m.State) > 0 {
+		for _, msg := range m.State {
+			dAtA[i] = 0x1a
+			i++
+			i = encodeVarintGenerated(dAtA, i, uint64(msg.ProtoSize()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
 		}
 	}
 	return i, nil
@@ -489,6 +676,24 @@ func (m *DriverPoolStatesRequest) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
+func (m *DriverStatesRequest) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DriverStatesRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
 func encodeFixed64Generated(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	dAtA[offset+1] = uint8(v >> 8)
@@ -516,6 +721,44 @@ func encodeVarintGenerated(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return offset + 1
 }
+func (m *DriverImageState) ProtoSize() (n int) {
+	var l int
+	_ = l
+	l = len(m.Reference)
+	if l > 0 {
+		n += 1 + l + sovGenerated(uint64(l))
+	}
+	l = len(m.Language)
+	if l > 0 {
+		n += 1 + l + sovGenerated(uint64(l))
+	}
+	l = len(m.Version)
+	if l > 0 {
+		n += 1 + l + sovGenerated(uint64(l))
+	}
+	l = github_com_gogo_protobuf_types.SizeOfStdTime(m.Build)
+	n += 1 + l + sovGenerated(uint64(l))
+	l = len(m.Status)
+	if l > 0 {
+		n += 1 + l + sovGenerated(uint64(l))
+	}
+	l = len(m.OS)
+	if l > 0 {
+		n += 1 + l + sovGenerated(uint64(l))
+	}
+	if len(m.NativeVersion) > 0 {
+		for _, s := range m.NativeVersion {
+			l = len(s)
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
+	l = len(m.GoVersion)
+	if l > 0 {
+		n += 1 + l + sovGenerated(uint64(l))
+	}
+	return n
+}
+
 func (m *DriverInstanceState) ProtoSize() (n int) {
 	var l int
 	_ = l
@@ -613,6 +856,26 @@ func (m *DriverPoolStatesResponse) ProtoSize() (n int) {
 	return n
 }
 
+func (m *DriverStatesResponse) ProtoSize() (n int) {
+	var l int
+	_ = l
+	if len(m.Errors) > 0 {
+		for _, s := range m.Errors {
+			l = len(s)
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
+	l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Elapsed)
+	n += 1 + l + sovGenerated(uint64(l))
+	if len(m.State) > 0 {
+		for _, e := range m.State {
+			l = e.ProtoSize()
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
+	return n
+}
+
 func (m *DriverInstanceStatesRequest) ProtoSize() (n int) {
 	var l int
 	_ = l
@@ -620,6 +883,12 @@ func (m *DriverInstanceStatesRequest) ProtoSize() (n int) {
 }
 
 func (m *DriverPoolStatesRequest) ProtoSize() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *DriverStatesRequest) ProtoSize() (n int) {
 	var l int
 	_ = l
 	return n
@@ -637,6 +906,289 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *DriverImageState) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DriverImageState: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DriverImageState: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Reference", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Reference = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Language", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Language = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Version", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Version = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Build", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := github_com_gogo_protobuf_types.StdTimeUnmarshal(&m.Build, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Status", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Status = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OS", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.OS = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NativeVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NativeVersion = append(m.NativeVersion, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field GoVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.GoVersion = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 func (m *DriverInstanceState) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
@@ -1393,6 +1945,146 @@ func (m *DriverPoolStatesResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *DriverStatesResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DriverStatesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DriverStatesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Errors", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Errors = append(m.Errors, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Elapsed", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := github_com_gogo_protobuf_types.StdDurationUnmarshal(&m.Elapsed, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field State", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.State = append(m.State, &DriverImageState{})
+			if err := m.State[len(m.State)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *DriverInstanceStatesRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1470,6 +2162,56 @@ func (m *DriverPoolStatesRequest) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: DriverPoolStatesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DriverStatesRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DriverStatesRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DriverStatesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:
@@ -1603,53 +2345,63 @@ func init() {
 }
 
 var fileDescriptorGenerated = []byte{
-	// 757 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x53, 0x41, 0x6f, 0xd3, 0x48,
-	0x18, 0xf5, 0xd8, 0x8d, 0xdd, 0x4e, 0x56, 0xdb, 0xc8, 0x5b, 0x75, 0x5d, 0xef, 0xae, 0xed, 0xad,
-	0x84, 0x14, 0x21, 0xe1, 0xa0, 0x70, 0x29, 0x95, 0x8a, 0xd4, 0x34, 0x01, 0x7a, 0xa0, 0x8d, 0x9c,
-	0xf6, 0xc2, 0xcd, 0x71, 0xa6, 0xae, 0x45, 0x62, 0x07, 0xcf, 0x38, 0xa5, 0xff, 0xa0, 0xea, 0x89,
-	0x13, 0x2a, 0x87, 0x4a, 0x45, 0x14, 0x89, 0x9f, 0xc1, 0xb1, 0x47, 0x0e, 0xf4, 0x5a, 0x50, 0x7a,
-	0xe0, 0xca, 0x99, 0x03, 0x42, 0xe3, 0x19, 0x2b, 0x21, 0xcd, 0xa1, 0x10, 0x71, 0xf3, 0x7c, 0xdf,
-	0x7b, 0xe3, 0xf7, 0xde, 0x37, 0x1f, 0x5c, 0xf2, 0x03, 0xb2, 0x9b, 0x34, 0x6d, 0x2f, 0xea, 0x94,
-	0x9a, 0xcd, 0xf6, 0x0e, 0xde, 0x2d, 0x61, 0x14, 0xf7, 0x50, 0x5c, 0x6a, 0xb9, 0xa8, 0x13, 0x85,
-	0xa5, 0x6e, 0x1c, 0x91, 0xc8, 0x8b, 0xda, 0x25, 0x1f, 0x85, 0x28, 0x76, 0x09, 0x6a, 0xd9, 0x69,
-	0x49, 0x2d, 0x0e, 0x98, 0x36, 0x63, 0xda, 0x8c, 0x69, 0x33, 0xa6, 0x9d, 0x31, 0xf5, 0x5b, 0x43,
-	0xff, 0xf0, 0x23, 0x3f, 0x62, 0x77, 0x36, 0x93, 0x9d, 0xf4, 0x94, 0x1e, 0xd2, 0x2f, 0xc6, 0xd0,
-	0x4d, 0x3f, 0x8a, 0xfc, 0x36, 0x1a, 0xa0, 0x48, 0xd0, 0x41, 0x98, 0xb8, 0x9d, 0x2e, 0x07, 0x18,
-	0xa3, 0x80, 0x56, 0x12, 0xbb, 0x24, 0xc8, 0x7e, 0xb9, 0xf8, 0x0d, 0xc0, 0xbf, 0xaa, 0x71, 0xd0,
-	0x43, 0xf1, 0x7a, 0x88, 0x89, 0x1b, 0x7a, 0xa8, 0x41, 0x5c, 0x82, 0xd4, 0x79, 0x28, 0x06, 0x2d,
-	0x0d, 0x58, 0xa0, 0x38, 0x53, 0x91, 0xfb, 0x17, 0xa6, 0xb8, 0x5e, 0x75, 0xc4, 0xa0, 0xa5, 0xce,
-	0xc1, 0x5c, 0xd0, 0x71, 0x7d, 0xa4, 0x89, 0xb4, 0xe5, 0xb0, 0x83, 0xfa, 0x10, 0xca, 0x98, 0xb8,
-	0x24, 0xc1, 0x9a, 0x64, 0x81, 0xe2, 0x9f, 0xe5, 0xdb, 0xf6, 0x75, 0x0d, 0xdb, 0x8d, 0x94, 0xe7,
-	0x70, 0xbe, 0x7a, 0x0f, 0x2a, 0x5e, 0x8c, 0x68, 0x74, 0xda, 0x94, 0x05, 0x8a, 0xf9, 0xb2, 0x6e,
-	0x33, 0x07, 0x76, 0xe6, 0xc0, 0xde, 0xca, 0x2c, 0x56, 0xa6, 0xcf, 0x2e, 0x4c, 0xe1, 0xf9, 0x47,
-	0x13, 0x38, 0x19, 0x49, 0xbd, 0x01, 0x67, 0xba, 0x71, 0xe4, 0x21, 0x8c, 0x11, 0xd6, 0x72, 0x96,
-	0x54, 0x94, 0x2a, 0xca, 0xd7, 0x0b, 0x53, 0x0a, 0x42, 0xe2, 0x0c, 0x3a, 0xcb, 0xd3, 0x07, 0x27,
-	0xa6, 0xf0, 0xe5, 0x95, 0x29, 0x2c, 0x7e, 0x00, 0xf0, 0xdf, 0x31, 0x01, 0x60, 0x07, 0xe1, 0x6e,
-	0x14, 0x62, 0x9a, 0x84, 0x8c, 0xe2, 0x38, 0x8a, 0xb1, 0x06, 0x2c, 0xa9, 0x38, 0xe3, 0xf0, 0x93,
-	0xba, 0x02, 0x15, 0xd4, 0x76, 0xbb, 0x18, 0xb5, 0xd2, 0x2c, 0xf2, 0xe5, 0x85, 0x2b, 0x4a, 0xab,
-	0x3c, 0x6b, 0x26, 0xf4, 0x28, 0x15, 0xca, 0x39, 0x6a, 0x03, 0xe6, 0xa8, 0x65, 0xa4, 0x49, 0x96,
-	0x54, 0xcc, 0x97, 0x57, 0xae, 0x9f, 0xd8, 0x18, 0xb5, 0x0e, 0xbb, 0x6b, 0xc8, 0xd6, 0x67, 0x00,
-	0x67, 0x19, 0xb0, 0x1e, 0x45, 0x6d, 0x36, 0x53, 0x13, 0xca, 0x7b, 0x6e, 0x48, 0xa3, 0xa5, 0x73,
-	0x1d, 0x0a, 0x86, 0x97, 0xd5, 0xff, 0xa1, 0x12, 0x27, 0x61, 0x18, 0x84, 0x7e, 0x6a, 0x69, 0x08,
-	0x91, 0xd5, 0x29, 0x64, 0xcf, 0x0d, 0x08, 0x85, 0x48, 0x23, 0x10, 0x5e, 0xa7, 0x10, 0x9c, 0x78,
-	0x34, 0xe8, 0x74, 0x84, 0xc3, 0x10, 0x5e, 0xa7, 0x4a, 0x78, 0xa6, 0xb9, 0x11, 0x25, 0x3c, 0x5c,
-	0x0a, 0x78, 0x16, 0x50, 0xa9, 0xf2, 0x28, 0x20, 0x2d, 0x0f, 0x39, 0x3d, 0x17, 0xa1, 0x36, 0xe2,
-	0xf4, 0xb7, 0x0f, 0xcf, 0xfb, 0x71, 0x78, 0x8f, 0x7e, 0x76, 0x78, 0x57, 0x95, 0xa6, 0x7b, 0x80,
-	0x6a, 0x21, 0x89, 0xf7, 0xf9, 0x30, 0x75, 0x0c, 0xe1, 0xa0, 0xa8, 0x16, 0xa0, 0xf4, 0x04, 0xed,
-	0xb3, 0x8d, 0x74, 0xe8, 0xa7, 0xba, 0x09, 0x73, 0x3d, 0xb7, 0x9d, 0x20, 0xee, 0xe0, 0xee, 0x2f,
-	0x8b, 0x70, 0xd8, 0x3d, 0xcb, 0xe2, 0x12, 0x18, 0xca, 0xf5, 0x3f, 0xf8, 0xcf, 0xf8, 0xbd, 0x78,
-	0x9a, 0x20, 0x4c, 0x16, 0x17, 0xe0, 0xdf, 0x57, 0xbd, 0xa4, 0xad, 0x9b, 0x2f, 0x00, 0x94, 0xd9,
-	0x5a, 0xab, 0x1a, 0x54, 0xd6, 0x9c, 0xda, 0xea, 0x56, 0xad, 0x5a, 0x10, 0xf4, 0xfc, 0xe1, 0xb1,
-	0xa5, 0xac, 0xf1, 0x45, 0xd5, 0xa0, 0xe2, 0x6c, 0x6f, 0x6c, 0xac, 0x6f, 0x3c, 0x28, 0x00, 0xd6,
-	0x71, 0xf8, 0x13, 0xd3, 0xa0, 0x52, 0x5f, 0xdd, 0x6e, 0xd0, 0x8e, 0xc8, 0x3a, 0x75, 0x37, 0xc1,
-	0xb4, 0x33, 0x0f, 0x65, 0xda, 0xa9, 0x55, 0x0b, 0x92, 0x0e, 0x0f, 0x8f, 0x2d, 0x99, 0x36, 0xd8,
-	0x5d, 0x8d, 0xad, 0xcd, 0x7a, 0xbd, 0x56, 0x2d, 0x4c, 0x31, 0x46, 0x83, 0x44, 0xdd, 0x2e, 0x6a,
-	0xe9, 0x7f, 0x1c, 0xbc, 0x36, 0x84, 0xb7, 0xa7, 0x86, 0xf0, 0xee, 0xd4, 0x10, 0xca, 0xe7, 0x22,
-	0x9c, 0xad, 0xf3, 0x10, 0x1a, 0x28, 0xee, 0x05, 0x1e, 0x52, 0xdf, 0x00, 0x38, 0x37, 0xce, 0xa7,
-	0x5a, 0x9b, 0x68, 0x23, 0xb3, 0x30, 0xf4, 0xfb, 0x93, 0x5e, 0xc3, 0x5f, 0xf2, 0x4b, 0x00, 0x0b,
-	0xa3, 0x81, 0xab, 0xab, 0x93, 0x3c, 0x3c, 0xa6, 0xaf, 0x32, 0xf9, 0xdb, 0xad, 0x18, 0x67, 0x7d,
-	0x03, 0xbc, 0xef, 0x1b, 0xe0, 0x53, 0xdf, 0x10, 0x8e, 0x2e, 0x0d, 0xe1, 0xe4, 0xd2, 0x00, 0x8f,
-	0xa7, 0x33, 0x62, 0x53, 0x4e, 0xbf, 0xee, 0x7c, 0x0f, 0x00, 0x00, 0xff, 0xff, 0x9d, 0x0e, 0xf2,
-	0xe0, 0x41, 0x07, 0x00, 0x00,
+	// 919 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x55, 0xcf, 0x8f, 0xdb, 0x44,
+	0x14, 0xf6, 0x8f, 0xc6, 0xce, 0xbe, 0x2d, 0x6d, 0x34, 0x94, 0xc5, 0x35, 0xad, 0x13, 0x56, 0xaa,
+	0x14, 0x21, 0xe1, 0xa0, 0x70, 0x29, 0x2b, 0xb5, 0xd2, 0xa6, 0x09, 0xb0, 0x07, 0x76, 0x23, 0x67,
+	0xcb, 0x81, 0x0b, 0x72, 0x9c, 0x59, 0xd7, 0x22, 0xf1, 0x84, 0x99, 0x71, 0x4a, 0xff, 0x83, 0xaa,
+	0x12, 0x12, 0x27, 0x54, 0x0e, 0x95, 0x0a, 0x14, 0x89, 0x3f, 0x83, 0x63, 0xb9, 0x71, 0x80, 0xeb,
+	0x82, 0xb6, 0x42, 0x5c, 0x39, 0x73, 0x40, 0x68, 0x3c, 0xe3, 0xc4, 0xc9, 0xee, 0xa1, 0xdb, 0x15,
+	0xbd, 0xf9, 0xbd, 0xf7, 0xbd, 0x99, 0xef, 0x7d, 0x6f, 0xde, 0x33, 0x5c, 0x8f, 0x13, 0x7e, 0x27,
+	0x1b, 0xfa, 0x11, 0x99, 0xb4, 0x86, 0xc3, 0xf1, 0x01, 0xbb, 0xd3, 0x62, 0x98, 0xce, 0x30, 0x6d,
+	0x8d, 0x42, 0x3c, 0x21, 0x69, 0x6b, 0x4a, 0x09, 0x27, 0x11, 0x19, 0xb7, 0x62, 0x9c, 0x62, 0x1a,
+	0x72, 0x3c, 0xf2, 0x73, 0x17, 0x6a, 0x2e, 0x32, 0x7d, 0x99, 0xe9, 0xcb, 0x4c, 0x5f, 0x66, 0xfa,
+	0x45, 0xa6, 0xfb, 0x76, 0xe9, 0x8e, 0x98, 0xc4, 0x44, 0x9e, 0x39, 0xcc, 0x0e, 0x72, 0x2b, 0x37,
+	0xf2, 0x2f, 0x99, 0xe1, 0xd6, 0x63, 0x42, 0xe2, 0x31, 0x5e, 0xa0, 0x78, 0x32, 0xc1, 0x8c, 0x87,
+	0x93, 0xa9, 0x02, 0x78, 0xab, 0x80, 0x51, 0x46, 0x43, 0x9e, 0x14, 0x57, 0x6e, 0x7e, 0x67, 0x40,
+	0xad, 0x4b, 0x93, 0x19, 0xa6, 0x3b, 0x93, 0x30, 0xc6, 0x03, 0x1e, 0x72, 0x8c, 0xae, 0xc0, 0x1a,
+	0xc5, 0x07, 0x98, 0xe2, 0x34, 0xc2, 0x8e, 0xde, 0xd0, 0x9b, 0x6b, 0xc1, 0xc2, 0x81, 0x5c, 0xa8,
+	0x8e, 0xc3, 0x34, 0xce, 0xc2, 0x18, 0x3b, 0x46, 0x1e, 0x9c, 0xdb, 0xc8, 0x01, 0x7b, 0x86, 0x29,
+	0x4b, 0x48, 0xea, 0x98, 0x79, 0xa8, 0x30, 0xd1, 0x16, 0x54, 0x86, 0x59, 0x32, 0x1e, 0x39, 0xe7,
+	0x1a, 0x7a, 0x73, 0xbd, 0xed, 0xfa, 0x92, 0x98, 0x5f, 0x10, 0xf3, 0xf7, 0x0b, 0xe6, 0x9d, 0xea,
+	0xd3, 0xc3, 0xba, 0xf6, 0xd5, 0xef, 0x75, 0x3d, 0x90, 0x29, 0x68, 0x03, 0x2c, 0xc6, 0x43, 0x9e,
+	0x31, 0xa7, 0x92, 0x1f, 0xaa, 0x2c, 0xb4, 0x01, 0x06, 0x61, 0x8e, 0x25, 0x7c, 0x1d, 0xeb, 0xe8,
+	0xb0, 0x6e, 0xec, 0x0d, 0x02, 0x83, 0x30, 0x74, 0x0d, 0x2e, 0xa4, 0x21, 0x4f, 0x66, 0xf8, 0xd3,
+	0x82, 0x8c, 0xdd, 0x30, 0x9b, 0x6b, 0xc1, 0x2b, 0xd2, 0xfb, 0xb1, 0xa2, 0x74, 0x15, 0x20, 0x26,
+	0x73, 0x48, 0x55, 0xd6, 0x19, 0x13, 0x15, 0xde, 0xaa, 0xde, 0x7f, 0x5c, 0xd7, 0xfe, 0xfe, 0xb6,
+	0xae, 0x6d, 0xfe, 0xab, 0xc3, 0xab, 0x4a, 0xa4, 0x94, 0xf1, 0x30, 0x8d, 0x94, 0x4e, 0x1b, 0x60,
+	0x24, 0x23, 0x29, 0x90, 0xbc, 0x7f, 0xa7, 0x1b, 0x18, 0xc9, 0x08, 0x5d, 0x82, 0x4a, 0x32, 0x59,
+	0xc8, 0x23, 0x0d, 0xf4, 0xe1, 0xbc, 0x0a, 0x21, 0xcd, 0x85, 0xf6, 0x3b, 0xfe, 0xf3, 0xbe, 0x0a,
+	0x7f, 0x90, 0xe7, 0xcd, 0xeb, 0xbe, 0x09, 0x76, 0x44, 0xb1, 0x78, 0x5f, 0xa7, 0x52, 0xb3, 0x48,
+	0x42, 0xd7, 0x60, 0x6d, 0x4a, 0x49, 0x84, 0x19, 0xc3, 0x42, 0x52, 0xb3, 0x69, 0x76, 0xec, 0x7f,
+	0x0e, 0xeb, 0x66, 0x92, 0xf2, 0x60, 0x11, 0x29, 0x09, 0xf0, 0xab, 0x0e, 0x57, 0x4e, 0x10, 0x80,
+	0x05, 0x98, 0x4d, 0x49, 0xca, 0x84, 0x12, 0x16, 0xa6, 0x94, 0x50, 0xe6, 0xe8, 0xb9, 0xd2, 0xca,
+	0x42, 0x37, 0xc0, 0xc6, 0xe3, 0x70, 0xca, 0xf0, 0x28, 0xd7, 0x62, 0xbd, 0x7d, 0xf9, 0x18, 0xd3,
+	0xae, 0x7a, 0x90, 0x92, 0xe8, 0xc3, 0x9c, 0xa8, 0xca, 0x41, 0x03, 0xa8, 0x88, 0x92, 0xb1, 0x63,
+	0x36, 0xcc, 0xe6, 0x7a, 0xfb, 0xc6, 0xf3, 0x2b, 0x76, 0x02, 0xdb, 0x40, 0x9e, 0x55, 0x2a, 0xeb,
+	0x2f, 0x1d, 0x2e, 0x4a, 0x60, 0x9f, 0x90, 0xb1, 0xec, 0x69, 0x1d, 0xac, 0xbb, 0x61, 0x2a, 0xa4,
+	0x15, 0x7d, 0x2d, 0x09, 0xa3, 0xdc, 0xe8, 0x4d, 0xb0, 0x69, 0x96, 0xa6, 0x49, 0x1a, 0xe7, 0x25,
+	0x95, 0x10, 0x85, 0x5f, 0x40, 0xee, 0x86, 0x09, 0x17, 0x10, 0x73, 0x05, 0xa2, 0xfc, 0x02, 0xc2,
+	0xb2, 0x48, 0x08, 0x9d, 0xb7, 0xb0, 0x0c, 0x51, 0x7e, 0xc1, 0x44, 0x69, 0x5a, 0x59, 0x61, 0xa2,
+	0xc4, 0x15, 0x80, 0x2f, 0x12, 0x41, 0xd5, 0x5a, 0x05, 0xe4, 0xee, 0x52, 0xa5, 0xbf, 0x19, 0xe0,
+	0xac, 0x54, 0xfa, 0xbf, 0x37, 0x2f, 0x5a, 0x6e, 0xde, 0x47, 0xa7, 0x6d, 0xde, 0x71, 0xa6, 0xf9,
+	0x1c, 0xe0, 0x5e, 0xca, 0xe9, 0x3d, 0xd5, 0x4c, 0x97, 0x01, 0x2c, 0x9c, 0xa8, 0x06, 0xe6, 0x67,
+	0xf8, 0x9e, 0x5a, 0x59, 0xe2, 0x13, 0xed, 0x41, 0x65, 0x16, 0x8e, 0x33, 0xac, 0x2a, 0x78, 0xef,
+	0x85, 0x49, 0x04, 0xf2, 0x9c, 0x2d, 0xe3, 0xba, 0x5e, 0xd2, 0xf5, 0x67, 0x1d, 0x2e, 0x49, 0xe0,
+	0xcb, 0xd1, 0xb4, 0xbf, 0xac, 0xe9, 0xd6, 0xa9, 0x07, 0x62, 0xbe, 0xe4, 0x8f, 0x4f, 0xc3, 0x55,
+	0x78, 0xe3, 0xe4, 0x19, 0xff, 0x3c, 0xc3, 0x8c, 0x6f, 0x5e, 0x86, 0xd7, 0x8f, 0xf7, 0x45, 0x86,
+	0x5e, 0x2b, 0xd6, 0xe3, 0x92, 0xfb, 0xad, 0xaf, 0x75, 0xb0, 0xe4, 0xe6, 0x12, 0xff, 0x85, 0x5b,
+	0x41, 0x6f, 0x7b, 0xbf, 0xd7, 0xad, 0x69, 0xee, 0xfa, 0x83, 0x47, 0x0d, 0xfb, 0x96, 0xda, 0x45,
+	0x0e, 0xd8, 0xc1, 0xed, 0xdd, 0xdd, 0x9d, 0xdd, 0x0f, 0x6a, 0xba, 0x8c, 0x04, 0x6a, 0x8a, 0x1c,
+	0xb0, 0xfb, 0xdb, 0xb7, 0x07, 0x22, 0x62, 0xc8, 0x48, 0x3f, 0xcc, 0x98, 0x88, 0x6c, 0x80, 0x25,
+	0x22, 0xbd, 0x6e, 0xcd, 0x74, 0xe1, 0xc1, 0xa3, 0x86, 0x25, 0x02, 0xf2, 0xac, 0xc1, 0xfe, 0x5e,
+	0xbf, 0xdf, 0xeb, 0xd6, 0xce, 0xc9, 0x8c, 0x01, 0x27, 0xd3, 0x29, 0x1e, 0xb9, 0xe7, 0xef, 0x7f,
+	0xef, 0x69, 0x3f, 0x3e, 0xf1, 0xb4, 0x9f, 0x9e, 0x78, 0x5a, 0xfb, 0x4f, 0x13, 0x2e, 0xf6, 0x95,
+	0x30, 0x03, 0x4c, 0x67, 0x49, 0x84, 0xd1, 0x0f, 0xf3, 0x4e, 0x2e, 0x97, 0x8f, 0x7a, 0x67, 0x5a,
+	0x3a, 0x85, 0x18, 0xee, 0xfb, 0x67, 0x3d, 0x46, 0x3d, 0xac, 0x6f, 0xf4, 0xe2, 0x87, 0xbd, 0xe8,
+	0x03, 0xda, 0x3e, 0xcb, 0x6c, 0x49, 0x7e, 0x9d, 0xb3, 0x8f, 0x27, 0xfa, 0x52, 0x87, 0xf3, 0xe5,
+	0x87, 0x80, 0x4e, 0xbd, 0xb0, 0x97, 0x39, 0xdd, 0x7c, 0xd1, 0x74, 0xc9, 0xa7, 0xe3, 0x3d, 0x3d,
+	0xf2, 0xf4, 0x5f, 0x8e, 0x3c, 0xfd, 0x8f, 0x23, 0x4f, 0x7b, 0xf8, 0xcc, 0xd3, 0x1e, 0x3f, 0xf3,
+	0xf4, 0x4f, 0xaa, 0x45, 0xd2, 0xd0, 0xca, 0xbf, 0xde, 0xfd, 0x2f, 0x00, 0x00, 0xff, 0xff, 0x91,
+	0x2a, 0x6a, 0x01, 0xd9, 0x09, 0x00, 0x00,
 }

--- a/daemon/protocol/generated.proto
+++ b/daemon/protocol/generated.proto
@@ -9,6 +9,19 @@ option (gogoproto.protosizer_all) = true;
 option (gogoproto.sizer_all) = false;
 option go_package = "protocol";
 
+message DriverImageState {
+	option (gogoproto.goproto_getters) = false;
+	option (gogoproto.typedecl) = false;
+	string reference = 1;
+	string language = 2;
+	string version = 3;
+	google.protobuf.Timestamp build = 4 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+	string status = 5;
+	string os = 6 [(gogoproto.customname) = "OS"];
+	repeated string native_version = 7;
+	string go_version = 8;
+}
+
 message DriverInstanceState {
 	option (gogoproto.goproto_getters) = false;
 	option (gogoproto.typedecl) = false;
@@ -46,10 +59,21 @@ message DriverPoolStatesResponse {
 	map<string, github.com.bblfsh.server.daemon.protocol.DriverPoolState> state = 3;
 }
 
+message DriverStatesResponse {
+	option (gogoproto.goproto_getters) = false;
+	option (gogoproto.typedecl) = false;
+	repeated string errors = 1;
+	google.protobuf.Duration elapsed = 2 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+	repeated github.com.bblfsh.server.daemon.protocol.DriverImageState state = 3;
+}
+
 message DriverInstanceStatesRequest {
 }
 
 message DriverPoolStatesRequest {
+}
+
+message DriverStatesRequest {
 }
 
 // Status is the status of a driver instance.
@@ -72,5 +96,6 @@ enum Status {
 service ProtocolService {
 	rpc DriverInstanceStates (github.com.bblfsh.server.daemon.protocol.DriverInstanceStatesRequest) returns (github.com.bblfsh.server.daemon.protocol.DriverInstanceStatesResponse);
 	rpc DriverPoolStates (github.com.bblfsh.server.daemon.protocol.DriverPoolStatesRequest) returns (github.com.bblfsh.server.daemon.protocol.DriverPoolStatesResponse);
+	rpc DriverStates (github.com.bblfsh.server.daemon.protocol.DriverStatesRequest) returns (github.com.bblfsh.server.daemon.protocol.DriverStatesResponse);
 }
 

--- a/daemon/protocol/server.proteus.go
+++ b/daemon/protocol/server.proteus.go
@@ -20,3 +20,8 @@ func (s *protocolServiceServer) DriverPoolStates(ctx xcontext.Context, in *Drive
 	result = DriverPoolStates()
 	return
 }
+func (s *protocolServiceServer) DriverStates(ctx xcontext.Context, in *DriverStatesRequest) (result *DriverStatesResponse, err error) {
+	result = new(DriverStatesResponse)
+	result = DriverStates()
+	return
+}

--- a/daemon/protocol/service.go
+++ b/daemon/protocol/service.go
@@ -12,6 +12,7 @@ var DefaultService Service
 type Service interface {
 	DriverPoolStates() map[string]*DriverPoolState
 	DriverInstanceStates() ([]*DriverInstanceState, error)
+	DriverStates() ([]*DriverImageState, error)
 }
 
 //proteus:generate
@@ -50,6 +51,30 @@ func DriverInstanceStates() *DriverInstanceStatesResponse {
 
 	var err error
 	resp.State, err = DefaultService.DriverInstanceStates()
+	if err != nil {
+		resp.Errors = append(resp.Errors, err.Error())
+	}
+
+	return resp
+}
+
+//proteus:generate
+type DriverStatesResponse struct {
+	protocol.Response
+	// State represent the state of each driver in the storage.
+	State []*DriverImageState
+}
+
+//proteus:generate
+func DriverStates() *DriverStatesResponse {
+	resp := &DriverStatesResponse{}
+	start := time.Now()
+	defer func() {
+		resp.Elapsed = time.Since(start)
+	}()
+
+	var err error
+	resp.State, err = DefaultService.DriverStates()
 	if err != nil {
 		resp.Errors = append(resp.Errors, err.Error())
 	}

--- a/daemon/protocol/types.go
+++ b/daemon/protocol/types.go
@@ -1,4 +1,4 @@
-//go:generate proteus -f $GOPATH/src -p github.com/bblfsh/server/daemon/protocol
+//go:generate proteus -f $GOPATH/src/ -p github.com/bblfsh/server/daemon/protocol --verbose
 //go:generate stringer -type=Status -output stringer.go
 
 package protocol
@@ -52,4 +52,28 @@ type DriverInstanceState struct {
 	Created time.Time `json:"created"`
 	// Processes are the pids of the processes running inside of the container.
 	Processes []int `json:"processes"`
+}
+
+//proteus:generate
+type DriverImageState struct {
+	// Referene is the image reference from where retrieved.
+	Reference string `json:"reference"`
+
+	// This fields are from manifest.Manifest, due to some limitation of
+	// proteus, can't be used directly.
+	// Language of the driver.
+	Language string `json:"language"`
+	// Version of the driver.
+	Version string `json:"version,omitempty"`
+	// Build time at the compilation of the image.
+	Build time.Time `json:"build,omitempty"`
+	// Status is the development status of the driver (alpha, beta, etc).
+	Status string `json:"status"`
+	// OS is the linux distribution running on the driver container.
+	OS string `json:"os"`
+	// Native version is the version of the compiler/interpreter being use in the
+	// native side of the driver.
+	NativeVersion []string `json:"native_version"`
+	// Go version of the go runtime being use in the driver.
+	GoVersion string `json:"go_version"`
 }

--- a/daemon/service.go
+++ b/daemon/service.go
@@ -156,3 +156,31 @@ func (s *ControlService) DriverInstanceStates() ([]*protocol.DriverInstanceState
 
 	return out, nil
 }
+
+func (s *ControlService) DriverStates() ([]*protocol.DriverImageState, error) {
+	list, err := s.daemon.runtime.ListDrivers()
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*protocol.DriverImageState
+	for _, d := range list {
+		build := d.Manifest.Build
+		if build == nil {
+			build = &time.Time{}
+		}
+
+		out = append(out, &protocol.DriverImageState{
+			Reference:     d.Reference,
+			Language:      d.Manifest.Language,
+			Version:       d.Manifest.Version,
+			Build:         *build,
+			Status:        string(d.Manifest.Status),
+			OS:            string(d.Manifest.Runtime.OS),
+			GoVersion:     string(d.Manifest.Runtime.GoVersion),
+			NativeVersion: []string(d.Manifest.Runtime.NativeVersion),
+		})
+	}
+
+	return out, nil
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 34a205c48df7ea42f44862c8d3b28abec00190e33a33d4693e8ade9fc846aac0
-updated: 2017-10-04T11:45:22.777618795+02:00
+hash: eff2d0184d200185de80d76f13a0c5a42ac427166d32b411accd8456c9a5ca7c
+updated: 2017-10-05T19:59:34.545795603+02:00
 imports:
 - name: github.com/BurntSushi/toml
   version: a368813c5e648fee92e5f6c30e3944ff9d5e8895
@@ -98,6 +98,8 @@ imports:
   version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 - name: github.com/docker/libtrust
   version: aabc10ec26b754e797f9028f4589c5b7bd90dc20
+- name: github.com/fatih/color
+  version: 5df930a27be2502f99b292b7cc09ebad4d0891f4
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/godbus/dbus
@@ -122,12 +124,16 @@ imports:
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
   version: ac112f7d75a0714af1bd86ab17749b31f7809640
+- name: github.com/hokaccha/go-prettyjson
+  version: e6b9231a2b1cc5798b336fdbf99c16cd8ad1e0c9
 - name: github.com/jessevdk/go-flags
   version: 96dc06278ce32a0e9d957d590bb987c81ee66407
 - name: github.com/mattn/go-colorable
-  version: ad5389df28cdac544c99bd7b9161a0b5b6ca9d1b
+  version: 5411d3eea5978e6cdc258b30de592b60df6aba96
+  repo: https://github.com/mattn/go-colorable
 - name: github.com/mattn/go-isatty
-  version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
+  version: 57fdcb988a5c543893cc61bce354a6e24ab70022
+  repo: https://github.com/mattn/go-isatty
 - name: github.com/mattn/go-runewidth
   version: 97311d9f7767e3d6f422ea06661bc2c7a19e8a5d
 - name: github.com/mgutz/ansi
@@ -184,9 +190,9 @@ imports:
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/seccomp/libseccomp-golang
   version: f6ec81daf48e41bf48b475afc7fe06a26bfb72d1
-- name: github.com/Sirupsen/logrus
-  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
 - name: github.com/sirupsen/logrus
+  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
+- name: github.com/Sirupsen/logrus
   version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
 - name: github.com/syndtr/gocapability
   version: db04d3cc01c8b54962a58ec7e491717d06cfcc16
@@ -219,7 +225,7 @@ imports:
   - proxy
   - trace
 - name: golang.org/x/sys
-  version: abf9c25f54453410d0c6668e519582a9e1115027
+  version: e24f485414aeafb646f6fca458b0bf869c0880a1
   subpackages:
   - unix
   - windows
@@ -252,14 +258,17 @@ imports:
   - tap
   - transport
 - name: gopkg.in/bblfsh/sdk.v1
-  version: 421904bf0bfbebd6b56c63a144f9c81ae87348ed
+  version: a130294d82f3cc9c7edd3182479a72c1f68fe031
   subpackages:
   - manifest
   - protocol
+  - sdk/driver
+  - sdk/jsonlines
   - sdk/server
   - uast
+  - uast/transformer
 - name: gopkg.in/src-d/enry.v1
-  version: 95ef0a6cf3f84c2eefafbef2bb9f9cde6144ea5d
+  version: c73f347afa18919a6fd6e4a3d48fbd341c850644
   subpackages:
   - data
   - internal/tokenizer

--- a/glide.yaml
+++ b/glide.yaml
@@ -37,6 +37,7 @@ import:
 - package: gopkg.in/src-d/go-errors.v1
   version: ^1.0.0
 - package: github.com/olekukonko/tablewriter
+- package: github.com/hokaccha/go-prettyjson
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4


### PR DESCRIPTION
It's implements a two new commands:
- parse: to parse files and prints the UAST or the AST, mainly for testing and demoing
- drivers: list the installed drivers. 